### PR TITLE
fix: `StateTransitionPublicSignals`, remove requirement of passing arguments to contractor

### DIFF
--- a/src/circuits/state-transition.ts
+++ b/src/circuits/state-transition.ts
@@ -78,7 +78,9 @@ interface StateTransitionInputsInternal {
 }
 
 export class StateTransitionPubSignals {
-  constructor(public userId: Id, public oldUserState: Hash, public newUserState: Hash) {}
+  userId: Id;
+  oldUserState: Hash;
+  newUserState: Hash
 
   // PubSignalsUnmarshal unmarshal stateTransition.circom public signals
   pubSignalsUnmarshal(data: Uint8Array): StateTransitionPubSignals {


### PR DESCRIPTION
[`StateTransitionPublicSignals`](https://github.com/iden3/polygonid-js-sdk/blob/e3a871c3a1fed00b2ceeaa06a33a3f60fc46888a/src/circuits/state-transition.ts#L81) right now requires to pass public signals as arguments in constructor, although its purpose is unmarshalling this data and sending us the public signals.

The PR makes this implementation consistent with the one done for [AuthV2](https://github.com/iden3/polygonid-js-sdk/blob/e3a871c3a1fed00b2ceeaa06a33a3f60fc46888a/src/circuits/auth-v2.ts#L114) circuit.