### PR TITLE
Feature/add publishstate method

### DIFF
--- a/src/storage/blockchain/state.ts
+++ b/src/storage/blockchain/state.ts
@@ -37,6 +37,7 @@ export const defaultEthConnectionConfig: EthConnectionConfig = {
 
 export class EthStateStorage implements IStateStorage {
   public stateContract: ethers.Contract;
+
   constructor(private readonly ethConfig: EthConnectionConfig = defaultEthConnectionConfig) {
     const provider = new ethers.providers.JsonRpcProvider(this.ethConfig.url);
     this.stateContract = new ethers.Contract(this.ethConfig.contractAddress, abi, provider);
@@ -71,8 +72,8 @@ export class EthStateStorage implements IStateStorage {
     );
 
     const txnReceipt = await tx.wait();
-    const status:number = txnReceipt.status;
-    const txnHash:string = txnReceipt.transactionHash;
+    const status: number = txnReceipt.status;
+    const txnHash: string = txnReceipt.transactionHash;
 
     if (status === 0) {
       throw new Error(`transaction: ${txnHash} failed to mined`);

--- a/tests/iden3comm/packageManager.test.ts
+++ b/tests/iden3comm/packageManager.test.ts
@@ -4,11 +4,7 @@ import {
   VerificationHandlerFunc
 } from '../../src/iden3comm/index';
 import ZKPPacker from '../../src/iden3comm/packers/zkp';
-import {
-  mockPrepareAuthInputs,
-  mockVerifyState,
-  ProvingMethodGroth16Authv2
-} from './mock/proving';
+import { mockPrepareAuthInputs, mockVerifyState, ProvingMethodGroth16Authv2 } from './mock/proving';
 import { proving, ProvingMethodAlg, ProvingMethod } from '@iden3/js-jwz';
 import { DID } from '@iden3/js-iden3-core';
 import {

--- a/tests/iden3comm/zkp.test.ts
+++ b/tests/iden3comm/zkp.test.ts
@@ -2,11 +2,7 @@ import { DID } from '@iden3/js-iden3-core';
 import { Token, ProvingMethodAlg, ProvingMethod, proving } from '@iden3/js-jwz';
 import { DataPrepareHandlerFunc, VerificationHandlerFunc } from '../../src/iden3comm';
 import ZKPPacker from '../../src/iden3comm/packers/zkp';
-import {
-  mockPrepareAuthInputs,
-  mockVerifyState,
-  ProvingMethodGroth16Authv2
-} from './mock/proving';
+import { mockPrepareAuthInputs, mockVerifyState, ProvingMethodGroth16Authv2 } from './mock/proving';
 import { ProvingParams, VerificationParams } from '../../src/iden3comm/types';
 import { AuthV2PubSignals } from '../../src/circuits';
 import { PROTOCOL_MESSAGE_TYPE } from '../../src/iden3comm/constants';


### PR DESCRIPTION
The PR adds `publishstate` function to publish identity state on chain via the [state smart contract.](https://github.com/iden3/contracts/blob/master/contracts/state/StateV2.sol)

Note:  Tests for the same will be added once we have proof generation service.