### PR TITLE
Create identity from imported key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ temp
 .idea
 .vscode
 /tests/proofs/testdata
+*.sw?

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -55,6 +55,7 @@ export interface IdentityCreationOptions {
     type: CredentialStatusType;
     nonce?: number;
   };
+  privKey?: Uint8Array;
   seed?: Uint8Array;
 }
 
@@ -285,9 +286,9 @@ export class IdentityWallet implements IIdentityWallet {
 
     await this._storage.mt.createIdentityMerkleTrees(tmpIdentifier);
 
-    opts.seed = opts.seed ?? getRandomBytes(32);
-
-    const keyID = await this._kms.createKeyFromSeed(KmsKeyType.BabyJubJub, opts.seed);
+    const keyID = opts.privKey ?
+      await this._kms.importKeyFromBytes(KmsKeyType.BabyJubJub, opts.privKey) :
+      await this._kms.createKeyFromSeed(KmsKeyType.BabyJubJub, opts.seed ?? getRandomBytes(32));
 
     const pubKey = (await this._kms.publicKey(keyID)) as PublicKey;
 

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -108,6 +108,15 @@ export interface IIdentityWallet {
   generateKey(keyType: KmsKeyType): Promise<KmsKeyId>;
 
   /**
+   * Imports a pre-existing key
+   *
+   * @param {KmsKeyType} keyType - supported key type by KMS
+   * @param {Uint8Array} bytes - byte array private key
+   * @returns `Promise<KmsKeyId>` - imports a pre-existing key BJJ or ECDSA
+   */
+  importKey(keyType: KmsKeyType, bytes: Uint8Array): Promise<KmsKeyId>;
+
+  /**
    * Issues new credential from issuer according to the claim request
    *
    * @param {DID} issuerDID - issuer identity
@@ -418,6 +427,12 @@ export class IdentityWallet implements IIdentityWallet {
   /** {@inheritDoc IIdentityWallet.generateKey} */
   async generateKey(keyType: KmsKeyType): Promise<KmsKeyId> {
     const key = await this._kms.createKeyFromSeed(keyType, getRandomBytes(32));
+    return key;
+  }
+
+  /** {@inheritDoc IIdentityWallet.importKey} */
+  async importKey(keyType: KmsKeyType, bytes: Uint8Array): Promise<KmsKeyId> {
+    const key = await this._kms.importKeyFromBytes(keyType, bytes);
     return key;
   }
 

--- a/src/kms/key-providers/bjj-provider.ts
+++ b/src/kms/key-providers/bjj-provider.ts
@@ -52,6 +52,29 @@ export class BjjProvider implements IKeyProvider {
   }
 
   /**
+   * imports a pre-existing baby jub jub key
+   * @param {Uint8Array} bytes - byte array private key
+   * @returns kms key identifier
+   */
+  async importPrivateKey(bytes: Uint8Array): Promise<KmsKeyId> {
+    if (bytes.length != 32) {
+      throw new Error('invalid key length')
+    }
+
+    const privateKey: PrivateKey = new PrivateKey(bytes);
+
+    const publicKey = privateKey.public();
+
+    const kmsId = {
+      type: this.keyType,
+      id: providerHelpers.keyPath(this.keyType, publicKey.hex())
+    };
+    await this.keyStore.import({ alias: kmsId.id, key: privateKey.hex() });
+
+    return kmsId;
+  }
+
+  /**
    * Gets public key by kmsKeyId
    *
    * @param {KmsKeyId} keyId - key identifier

--- a/src/kms/key-providers/sec256k1-provider.ts
+++ b/src/kms/key-providers/sec256k1-provider.ts
@@ -50,6 +50,15 @@ export class Sec256k1Provider implements IKeyProvider {
   }
 
   /**
+   * imports a pre-existing baby jub jub key
+   * @param {Uint8Array} buffer - byte array private key
+   * @returns kms key identifier
+   */
+  async importPrivateKey(bytes: Uint8Array): Promise<KmsKeyId> {
+    throw new Error("Not Implemented")
+  }
+
+  /**
    * Gets public key by kmsKeyId
    *
    * @param {KmsKeyId} keyId - key identifier

--- a/src/kms/kms.ts
+++ b/src/kms/kms.ts
@@ -39,6 +39,14 @@ export interface IKeyProvider {
    * @returns `Promise<KmsKeyId>`
    */
   newPrivateKeyFromSeed(seed: Uint8Array): Promise<KmsKeyId>;
+
+  /**
+   * imports a pre-existing key
+   *
+   * @param {Uint8Array} bytes - private key
+   * @returns `Promise<KmsKeyId>`
+   */
+  importPrivateKey(bytes: Uint8Array): Promise<KmsKeyId>;
 }
 /**
  * Key management system class contains different key providers.
@@ -82,6 +90,21 @@ export class KMS {
       throw new Error(`keyProvider not found for: ${keyType}`);
     }
     return keyProvider.newPrivateKeyFromSeed(bytes);
+  }
+
+  /**
+   * imports a pre-existing key and returns it kms key id
+   *
+   * @param {KmsKeyType} keyType
+   * @param {Uint8Array} bytes
+   * @returns kms key id
+   */
+  async importKeyFromBytes(keyType: KmsKeyType, bytes: Uint8Array): Promise<KmsKeyId> {
+    const keyProvider = this.registry[keyType];
+    if (!keyProvider) {
+      throw new Error(`keyProvider not found for: ${keyType}`);
+    }
+    return keyProvider.importPrivateKey(bytes);
   }
 
   /**

--- a/tests/kms/import-key.test.ts
+++ b/tests/kms/import-key.test.ts
@@ -1,0 +1,51 @@
+import { BjjProvider, KMS, KmsKeyType } from '../../src/kms';
+import { InMemoryPrivateKeyStore } from '../../src/kms/store';
+import { Hex, PrivateKey, PublicKey } from '@iden3/js-crypto'
+import { expect } from 'chai';
+
+describe('import', () => {
+  let bjjProvider: BjjProvider;
+
+  const keyBytes = Hex.decodeString(
+    '2d45d0cb81682bde9883a326ba1344208193b76f36091274f45b4c4940faed5b'
+  );
+
+  beforeEach(async () => {
+    const memoryKeyStore = new InMemoryPrivateKeyStore();
+    bjjProvider = new BjjProvider(KmsKeyType.BabyJubJub, memoryKeyStore);
+  });
+
+  it('baby jub jub into provider', async () => {
+    const privateKey = new PrivateKey(keyBytes);
+    const pubKey = privateKey.public();
+
+    const kmsKeyId = await bjjProvider.importPrivateKey(keyBytes);
+    const { type: keyType, id: keyId } = kmsKeyId;
+    expect(keyType).to.equal(KmsKeyType.BabyJubJub);
+    expect(keyId).to.equal(`${keyType}:${pubKey.hex()}`);
+
+    const kms = new KMS();
+    kms.registerKeyProvider(KmsKeyType.BabyJubJub, bjjProvider);
+    const pub = await kms.publicKey(kmsKeyId) as PublicKey;
+    expect(pub.p[0]).to.equal(pubKey.p[0]);
+    expect(pub.p[1]).to.equal(pubKey.p[1]);
+  });
+
+
+  it('baby jub jub into kms', async () => {
+    const privateKey = new PrivateKey(keyBytes);
+    const pubKey = privateKey.public();
+
+    const kms = new KMS();
+    kms.registerKeyProvider(KmsKeyType.BabyJubJub, bjjProvider);
+
+    const kmsKeyId = await kms.importKeyFromBytes(KmsKeyType.BabyJubJub, keyBytes);
+    const { type: keyType, id: keyId } = kmsKeyId;
+    expect(keyType).to.equal(KmsKeyType.BabyJubJub);
+    expect(keyId).to.equal(`${keyType}:${pubKey.hex()}`);
+
+    const pub = await kms.publicKey(kmsKeyId) as PublicKey;
+    expect(pub.p[0]).to.equal(pubKey.p[0]);
+    expect(pub.p[1]).to.equal(pubKey.p[1]);
+  });
+});


### PR DESCRIPTION
Option for importing BabyJubJub keys instead of creating fresh ones from seed phrases:

```ts
const keyBytes = ... // 32 bytes array representing a BabyJubJub private key

const wallet = new IdentityWallet(kms, dataStorage, credWallet);
const { did, credential } = await wallet.createIdentity({
  method: DidMethod.Iden3,
  blockchain: Blockchain.Polygon,
  networkId: NetworkId.Mumbai,
  privKey: keyBytes,
  revocationOpts: {
    type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
    baseUrl: 'http://rhs.com/node'
  }
});
```

This calls the following API  of the key management service:

```ts
const kms = new KMS();
kms.registerKeyProvider(KmsKeyType.BabyJubJub, bjjProvider);
const keyId = await kms.importKeyFromBytes(KmsKeyType.BabyJubJub, keyBytes);
```

At the key provider layer, this looks as follows:

```ts
const memoryKeyStore = new InMemoryPrivateKeyStore();
const bjjProvider = new BjjProvider(KmsKeyType.BabyJubJub, memoryKeyStore);
const keyId = await bjjProvider.importPrivateKey(keyBytes);
```