### PR TITLE
feat: Idea to enfoce node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -101,5 +101,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "engines": {
+    "node": ">=18.16.1"
+   }
 }


### PR DESCRIPTION
Added to package.json and npmrc file to warn the user to change to a higher version of node to support fetch

BREAKING CHANGE: No

Enforces node v18.16.1 to avoid using lower versions of node that don't have fetch and other libraries out of the box.

```bash
# Example Warning
pnpm install;

# [Expected Output]
#  ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
# 
# Your Node version is incompatible with "/path/to/0xPolygonID--js-sdk".
# 
# Expected version: >=18.16.1
# Got: v16.17.0
# 
# This is happening because the package's manifest has an engines.node field specified.
# To fix this issue, install the required Node version.
```
