### PR TITLE
Fix: validating same schema multiple times when it has $id

### DIFF
--- a/src/schema-processor/json/validator.ts
+++ b/src/schema-processor/json/validator.ts
@@ -43,7 +43,8 @@ export class JsonSchemaValidator {
     if (validator.formats && !Object.keys(validator.formats).length) {
       addFormats(validator);
     }
-    const validate = validator.compile(schema);
+    const validate =
+      (schema.$id ? validator.getSchema(schema.$id) : undefined) || validator.compile(schema);
     const valid = validate(data);
     if (!valid) {
       throw new Error(validate.errors?.map((e) => e.message).join(', '));


### PR DESCRIPTION
AJV throws an error if you compile a schema with same ID twice. See: https://ajv.js.org/guide/managing-schemas.html