### PR TITLE
Manage ethereum based identities

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
             publishState: async () => {
               return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
             },
+            publishStateGeneric: async () => {
+              return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+            },
             getGISTProof: () => {
               return Promise.resolve({
                 root: 0n,

--- a/src/credentials/status/reverse-sparse-merkle-tree.ts
+++ b/src/credentials/status/reverse-sparse-merkle-tree.ts
@@ -173,7 +173,17 @@ export class RHSResolver implements CredentialStatusResolver {
         return this.getRevocationStatusFromIssuerData(issuerDID, issuerData, genesisState);
       }
       const currentStateBigInt = Hash.fromHex(stateHex).bigInt();
-      if (!isGenesisState(issuerDID, currentStateBigInt)) {
+
+      const issuerId = DID.idFromDID(issuerDID);
+      let isBjjIdentity = false; // don't generate proof for ethereum identities
+      try {
+        Id.ethAddressFromId(issuerId);
+      } catch {
+        // not an ethereum identity
+        isBjjIdentity = true;
+      }
+
+      if (isBjjIdentity && !isGenesisState(issuerDID, currentStateBigInt)) {
         throw new Error(
           `latest state not found and state parameter ${stateHex} is not genesis state`
         );

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -669,11 +669,22 @@ export class IdentityWallet implements IIdentityWallet {
       authClaim.hiHv().hv
     );
 
+    const claimsTree = await this._storage.mt.getMerkleTreeByIdentifierAndType(
+      did.string(),
+      MerkleTreeType.Claims
+    );
+
+    const stateAuthClaim = hashElems([
+      (await claimsTree.root()).bigInt(),
+      ZERO_HASH.bigInt(),
+      ZERO_HASH.bigInt()
+    ]);
+
     const credential = await this.createAuthCredential(
       did,
       pubKey,
       authClaim,
-      currentState,
+      stateAuthClaim,
       opts.revocationOpts
     );
 

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -80,12 +80,14 @@ export type IdentityCreationOptions = {
     };
   };
   seed?: Uint8Array;
+};
+
+export type EthereumBasedIdentityCreationOptions = IdentityCreationOptions & {
   ethereumBasedIdentityOpts?: {
     ethSigner?: Signer;
     createBjjCredential?: boolean;
   };
 };
-
 /**
  * Options for RevocationInfoOptions.
  */
@@ -135,7 +137,7 @@ export interface IIdentityWallet {
    * @public
    */
   createEthereumBasedIdentity(
-    opts: IdentityCreationOptions
+    opts: EthereumBasedIdentityCreationOptions
   ): Promise<{ did: DID; credential: W3CCredential | undefined }>;
 
   /**
@@ -640,7 +642,7 @@ export class IdentityWallet implements IIdentityWallet {
    * {@inheritDoc IIdentityWallet.createEthereumBasedIdentity}
    */
   async createEthereumBasedIdentity(
-    opts: IdentityCreationOptions
+    opts: EthereumBasedIdentityCreationOptions
   ): Promise<{ did: DID; credential: W3CCredential | undefined }> {
     opts.seed = opts.seed ?? getRandomBytes(32);
     if (opts.ethereumBasedIdentityOpts) {

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -115,7 +115,7 @@ export interface IIdentityWallet {
    * adds auth BJJ credential to claims tree and generates mtp of inclusion
    * based on the resulting state it provides an identifier in DID form.
    *
-   * @param {IdentityCreationOptions} opts - default is did:iden3:polygon:mumbai** with generated key.
+   * @param {IdentityCreationOptions} opts - default is did:iden3:polygon:aloy** with generated key.
    * @returns `Promise<{ did: DID; credential: W3CCredential }>` - returns did and Auth BJJ credential
    * @public
    */
@@ -551,7 +551,7 @@ export class IdentityWallet implements IIdentityWallet {
 
     opts.method = opts.method ?? DidMethod.Iden3;
     opts.blockchain = opts.blockchain ?? Blockchain.Polygon;
-    opts.networkId = opts.networkId ?? NetworkId.Mumbai;
+    opts.networkId = opts.networkId ?? NetworkId.Aloy;
     opts.seed = opts.seed ?? getRandomBytes(32);
 
     await this._storage.mt.createIdentityMerkleTrees(tmpIdentifier);
@@ -624,7 +624,7 @@ export class IdentityWallet implements IIdentityWallet {
   ): Promise<{ did: DID; credential: W3CCredential }> {
     opts.method = opts.method ?? DidMethod.Iden3;
     opts.blockchain = opts.blockchain ?? Blockchain.Polygon;
-    opts.networkId = opts.networkId ?? NetworkId.Mumbai;
+    opts.networkId = opts.networkId ?? NetworkId.Aloy;
     opts.seed = opts.seed ?? getRandomBytes(32);
 
     const proofService = opts.proofService;

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -94,10 +94,8 @@ export type AuthBJJCredentialCreationOptions = {
  * Options for creating Ethereum based identity
  */
 export type EthereumBasedIdentityCreationOptions = IdentityCreationOptions & {
-  ethereumBasedIdentityOpts?: {
-    ethSigner?: Signer;
-    createBjjCredential?: boolean;
-  };
+  ethSigner?: Signer;
+  createBjjCredential?: boolean;
 };
 
 /**
@@ -679,13 +677,10 @@ export class IdentityWallet implements IIdentityWallet {
     opts: EthereumBasedIdentityCreationOptions
   ): Promise<{ did: DID; credential: W3CCredential | undefined }> {
     opts.seed = opts.seed ?? getRandomBytes(32);
-    if (opts.ethereumBasedIdentityOpts) {
-      opts.ethereumBasedIdentityOpts.createBjjCredential =
-        opts.ethereumBasedIdentityOpts?.createBjjCredential ?? true;
-    }
+    opts.createBjjCredential = opts.createBjjCredential ?? true;
 
     let credential;
-    const ethSigner = opts.ethereumBasedIdentityOpts?.ethSigner;
+    const ethSigner = opts.ethSigner;
 
     if (!ethSigner) {
       throw new Error(
@@ -714,7 +709,7 @@ export class IdentityWallet implements IIdentityWallet {
       isStateGenesis: true
     });
 
-    if (opts.ethereumBasedIdentityOpts?.createBjjCredential) {
+    if (opts.createBjjCredential) {
       // Old tree state genesis state
       const oldTreeState: TreeState = {
         revocationRoot: ZERO_HASH,

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -624,6 +624,12 @@ export class IdentityWallet implements IIdentityWallet {
     const proofService = opts.proofService;
     const ethSigner = opts.ethSigner;
 
+    if (!ethSigner) {
+      throw new Error(
+        'Ethereum signer is required to create Ethereum identities in order to transit state'
+      );
+    }
+
     const currentState = ZERO_HASH; // In Ethereum identities we don't have an initial state with the auth credential
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -80,8 +80,10 @@ export type IdentityCreationOptions = {
     };
   };
   seed?: Uint8Array;
-  ethSigner?: Signer;
-  createBjjCredential?: boolean;
+  ethereumBasedIdentityOpts?: {
+    ethSigner?: Signer;
+    createBjjCredential?: boolean;
+  };
 };
 
 /**
@@ -645,10 +647,13 @@ export class IdentityWallet implements IIdentityWallet {
     opts: IdentityCreationOptions
   ): Promise<{ did: DID; credential: W3CCredential | undefined }> {
     opts.seed = opts.seed ?? getRandomBytes(32);
-    opts.createBjjCredential = opts.createBjjCredential ?? true;
+    if (opts.ethereumBasedIdentityOpts) {
+      opts.ethereumBasedIdentityOpts.createBjjCredential =
+        opts.ethereumBasedIdentityOpts?.createBjjCredential ?? true;
+    }
 
     let credential;
-    const ethSigner = opts.ethSigner;
+    const ethSigner = opts.ethereumBasedIdentityOpts?.ethSigner;
 
     if (!ethSigner) {
       throw new Error(
@@ -677,7 +682,7 @@ export class IdentityWallet implements IIdentityWallet {
       isStateGenesis: true
     });
 
-    if (opts.createBjjCredential) {
+    if (opts.ethereumBasedIdentityOpts?.createBjjCredential) {
       // Old tree state genesis state
       const oldTreeState: TreeState = {
         revocationRoot: ZERO_HASH,

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -21,7 +21,7 @@ import {
   getRandomBytes,
   Poseidon
 } from '@iden3/js-crypto';
-import { Hash, hashElems, ZERO_HASH } from '@iden3/js-merkletree';
+import { hashElems, ZERO_HASH } from '@iden3/js-merkletree';
 import { generateProfileDID, subjectPositionIndex } from './common';
 import * as uuid from 'uuid';
 import { JSONSchema, JsonSchemaValidator, cacheLoader } from '../schema-processor';
@@ -1391,6 +1391,11 @@ export class IdentityWallet implements IIdentityWallet {
     prover?: IZKProver // it will be needed in case of non ethereum identities
   ): Promise<W3CCredential> {
     opts.seed = opts.seed ?? getRandomBytes(32);
+    opts.revocationOpts.nonce =
+      opts.revocationOpts.nonce ??
+      (isOldStateGenesis
+        ? 0
+        : opts.revocationOpts.nonce ?? new DataView(getRandomBytes(12).buffer).getUint32(0));
 
     const { authClaim, pubKey } = await this.createAuthCoreClaim(
       opts.revocationOpts.nonce ?? 0,

--- a/src/identity/identity-wallet.ts
+++ b/src/identity/identity-wallet.ts
@@ -1168,7 +1168,9 @@ export class IdentityWallet implements IIdentityWallet {
       if (Array.isArray(credentials[index].proof)) {
         (credentials[index].proof as unknown[]).push(mtpProof);
       } else {
-        credentials[index].proof = [credentials[index].proof, mtpProof];
+        credentials[index].proof = credentials[index].proof
+          ? [credentials[index].proof, mtpProof]
+          : [mtpProof];
       }
     }
     return credentials;

--- a/src/kms/key-providers/sec256k1-provider.ts
+++ b/src/kms/key-providers/sec256k1-provider.ts
@@ -42,7 +42,7 @@ export class Sec256k1Provider implements IKeyProvider {
     const keyPair = this._ec.keyFromPrivate(seed);
     const kmsId = {
       type: this.keyType,
-      id: providerHelpers.keyPath(this.keyType, keyPair.getPublic().encode('hex', false))
+      id: providerHelpers.keyPath(this.keyType, keyPair.getPublic().encode('hex', false)) // 04 + x + y (uncompressed key)
     };
     await this._keyStore.importKey({ alias: kmsId.id, key: keyPair.getPrivate().toString('hex') });
 
@@ -56,7 +56,7 @@ export class Sec256k1Provider implements IKeyProvider {
    */
   async publicKey(keyId: KmsKeyId): Promise<string> {
     const privateKeyHex = await this.privateKey(keyId);
-    return this._ec.keyFromPrivate(privateKeyHex, 'hex').getPublic().encode('hex', false);
+    return this._ec.keyFromPrivate(privateKeyHex, 'hex').getPublic().encode('hex', false); // 04 + x + y (uncompressed key)
   }
 
   /**

--- a/src/kms/key-providers/sec256k1-provider.ts
+++ b/src/kms/key-providers/sec256k1-provider.ts
@@ -44,7 +44,10 @@ export class Sec256k1Provider implements IKeyProvider {
       type: this.keyType,
       id: providerHelpers.keyPath(this.keyType, keyPair.getPublic().encode('hex', false)) // 04 + x + y (uncompressed key)
     };
-    await this._keyStore.importKey({ alias: kmsId.id, key: keyPair.getPrivate().toString('hex') });
+    await this._keyStore.importKey({
+      alias: kmsId.id,
+      key: keyPair.getPrivate().toString('hex').padStart(64, '0')
+    });
 
     return kmsId;
   }

--- a/src/kms/key-providers/sec256k1-provider.ts
+++ b/src/kms/key-providers/sec256k1-provider.ts
@@ -42,7 +42,7 @@ export class Sec256k1Provider implements IKeyProvider {
     const keyPair = this._ec.keyFromPrivate(seed);
     const kmsId = {
       type: this.keyType,
-      id: providerHelpers.keyPath(this.keyType, keyPair.getPublic().encode('hex', false)) // 04 + x + y (uncompressed key)
+      id: providerHelpers.keyPath(this.keyType, keyPair.getPublic().encode('hex', false))
     };
     await this._keyStore.importKey({
       alias: kmsId.id,

--- a/src/proof/proof-service.ts
+++ b/src/proof/proof-service.ts
@@ -350,7 +350,13 @@ export class ProofService implements IProofService {
     stateStorage: IStateStorage, // for compatibility with previous versions we leave this parameter
     ethSigner: Signer
   ): Promise<string> {
-    return this._identityWallet.transitState(did, oldTreeState, isOldStateGenesis, ethSigner);
+    return this._identityWallet.transitState(
+      did,
+      oldTreeState,
+      isOldStateGenesis,
+      ethSigner,
+      this._prover
+    );
   }
 
   private async generateInputs(

--- a/src/proof/proof-service.ts
+++ b/src/proof/proof-service.ts
@@ -42,7 +42,6 @@ import {
 } from './provers/inputs-generator';
 import { PubSignalsVerifier, VerifyContext } from './verifiers/pub-signals-verifier';
 import { VerifyOpts } from './verifiers';
-import { KmsKeyType } from '../kms';
 
 export interface QueryWithFieldName {
   query: Query;

--- a/src/proof/proof-service.ts
+++ b/src/proof/proof-service.ts
@@ -135,6 +135,7 @@ export interface IProofService {
     did: DID,
     oldTreeState: TreeState,
     isOldStateGenesis: boolean,
+    stateStorage: IStateStorage,
     ethSigner: Signer
   ): Promise<string>;
 
@@ -346,6 +347,7 @@ export class ProofService implements IProofService {
     did: DID,
     oldTreeState: TreeState,
     isOldStateGenesis: boolean,
+    stateStorage: IStateStorage, // for compatibility with previous versions we leave this parameter
     ethSigner: Signer
   ): Promise<string> {
     return this._identityWallet.transitState(did, oldTreeState, isOldStateGenesis, ethSigner);

--- a/src/proof/proof-service.ts
+++ b/src/proof/proof-service.ts
@@ -1,15 +1,6 @@
-import { Poseidon } from '@iden3/js-crypto';
-import { BytesHelper, DID, Id, MerklizedRootPosition } from '@iden3/js-iden3-core';
+import { BytesHelper, DID, MerklizedRootPosition } from '@iden3/js-iden3-core';
 import { Hash } from '@iden3/js-merkletree';
-import {
-  AuthV2Inputs,
-  CircuitId,
-  Operators,
-  Query,
-  StateTransitionInputs,
-  TreeState,
-  ValueProof
-} from '../circuits';
+import { AuthV2Inputs, CircuitId, Operators, Query, TreeState, ValueProof } from '../circuits';
 import { ICredentialWallet } from '../credentials';
 import { IIdentityWallet } from '../identity';
 import {
@@ -33,7 +24,7 @@ import { ZKProof } from '@iden3/js-jwz';
 import { Signer } from 'ethers';
 import { JSONObject, ZeroKnowledgeProofRequest, ZeroKnowledgeProofResponse } from '../iden3comm';
 import { cacheLoader } from '../schema-processor';
-import { ICircuitStorage, IStateStorage, UserStateTransitionInfo } from '../storage';
+import { ICircuitStorage, IStateStorage } from '../storage';
 import { byteDecoder, byteEncoder } from '../utils/encoding';
 import {
   InputGenerator,
@@ -42,7 +33,6 @@ import {
 } from './provers/inputs-generator';
 import { PubSignalsVerifier, VerifyContext } from './verifiers/pub-signals-verifier';
 import { VerifyOpts } from './verifiers';
-import { isEthereumIdentity } from '../utils';
 
 export interface QueryWithFieldName {
   query: Query;

--- a/src/proof/provers/inputs-generator.ts
+++ b/src/proof/provers/inputs-generator.ts
@@ -37,6 +37,7 @@ import {
   ICredentialWallet,
   getUserDIDFromCredential
 } from '../../credentials';
+import { isEthereumIdentity } from '../../utils';
 
 export type DIDProfileMetadata = {
   authProfileNonce: number;
@@ -537,12 +538,7 @@ export class InputGenerator {
       ? BigInt(proofReq.params?.nullifierSessionId?.toString())
       : BigInt(0);
 
-    let isEthIdentity = true;
-    try {
-      Id.ethAddressFromId(circuitInputs.id);
-    } catch {
-      isEthIdentity = false;
-    }
+    const isEthIdentity = isEthereumIdentity(identifier);
     circuitInputs.isBJJAuthEnabled = isEthIdentity ? 0 : 1;
 
     circuitInputs.challenge = BigInt(params.challenge ?? 0);

--- a/src/proof/provers/inputs-generator.ts
+++ b/src/proof/provers/inputs-generator.ts
@@ -1,4 +1,4 @@
-import { DID, Id, getUnixTimestamp } from '@iden3/js-iden3-core';
+import { DID, getUnixTimestamp } from '@iden3/js-iden3-core';
 import {
   Iden3SparseMerkleTreeProof,
   ProofType,

--- a/src/storage/blockchain/state.ts
+++ b/src/storage/blockchain/state.ts
@@ -160,7 +160,7 @@ export class EthStateStorage implements IStateStorage {
     return txnHash;
   }
 
-  /** {@inheritdoc IStateStorage.publishState} */
+  /** {@inheritdoc IStateStorage.publishStateGeneric} */
   async publishStateGeneric(
     signer: Signer,
     userStateTranstionInfo: UserStateTransitionInfo

--- a/src/storage/blockchain/state.ts
+++ b/src/storage/blockchain/state.ts
@@ -156,7 +156,6 @@ export class EthStateStorage implements IStateStorage {
             BigInt(1),
             []
           ];
-          console.log('Calling transitStateGeneric!!!!!', payload);
           gasLimit = await contract.transitStateGeneric.estimateGas(...payload);
           txData = await contract.transitStateGeneric.populateTransaction(...payload);
         }

--- a/src/storage/blockchain/state.ts
+++ b/src/storage/blockchain/state.ts
@@ -163,10 +163,10 @@ export class EthStateStorage implements IStateStorage {
   /** {@inheritdoc IStateStorage.publishStateGeneric} */
   async publishStateGeneric(
     signer: Signer,
-    userStateTranstionInfo: UserStateTransitionInfo
+    userStateTransitionInfo: UserStateTransitionInfo
   ): Promise<string> {
     const { userId, oldUserState, newUserState, isOldStateGenesis, methodId, methodParams } =
-      userStateTranstionInfo;
+      userStateTransitionInfo;
     const { stateContract, provider } = this.getStateContractAndProviderForId(userId.bigInt());
     const contract = stateContract.connect(signer) as Contract;
     const feeData = await provider.getFeeData();

--- a/src/storage/blockchain/state.ts
+++ b/src/storage/blockchain/state.ts
@@ -1,7 +1,7 @@
 import { RootInfo, StateProof } from './../entities/state';
 import { ZKProof } from '@iden3/js-jwz';
 import { IStateStorage, UserStateTransitionInfo } from '../interfaces/state';
-import { Contract, ContractTransaction, JsonRpcProvider, Signer, TransactionRequest } from 'ethers';
+import { Contract, JsonRpcProvider, Signer, TransactionRequest } from 'ethers';
 import { StateInfo } from '../entities/state';
 import { StateTransitionPubSignals } from '../../circuits';
 import { byteEncoder } from '../../utils';
@@ -165,7 +165,8 @@ export class EthStateStorage implements IStateStorage {
     signer: Signer,
     userStateTranstionInfo: UserStateTransitionInfo
   ): Promise<string> {
-    const { userId, oldUserState, newUserState, isOldStateGenesis, methodId, methodParams } = userStateTranstionInfo;
+    const { userId, oldUserState, newUserState, isOldStateGenesis, methodId, methodParams } =
+      userStateTranstionInfo;
     const { stateContract, provider } = this.getStateContractAndProviderForId(userId.bigInt());
     const contract = stateContract.connect(signer) as Contract;
     const feeData = await provider.getFeeData();

--- a/src/storage/blockchain/state.ts
+++ b/src/storage/blockchain/state.ts
@@ -144,18 +144,8 @@ export class EthStateStorage implements IStateStorage {
       maxFeePerGas,
       maxPriorityFeePerGas
     };
-    const tx = await signer.sendTransaction(request);
 
-    const txnReceipt = await tx.wait();
-    if (!txnReceipt) {
-      throw new Error(`transaction: ${tx.hash} failed to mined`);
-    }
-    const status: number | null = txnReceipt.status;
-    const txnHash: string = txnReceipt.hash;
-
-    if (!status) {
-      throw new Error(`transaction: ${txnHash} failed to mined`);
-    }
+    const txnHash: string = await this.sendTransactionRequest(signer, request);
 
     return txnHash;
   }
@@ -196,17 +186,8 @@ export class EthStateStorage implements IStateStorage {
       maxFeePerGas,
       maxPriorityFeePerGas
     };
-    const tx = await signer.sendTransaction(request);
-    const txnReceipt = await tx.wait();
-    if (!txnReceipt) {
-      throw new Error(`transaction: ${tx.hash} failed to mined`);
-    }
-    const status: number | null = txnReceipt.status;
-    const txnHash: string = txnReceipt.hash;
 
-    if (!status) {
-      throw new Error(`transaction: ${txnHash} failed to mined`);
-    }
+    const txnHash: string = await this.sendTransactionRequest(signer, request);
 
     return txnHash;
   }
@@ -277,5 +258,24 @@ export class EthStateStorage implements IStateStorage {
     }
 
     return this.ethConfig as EthConnectionConfig;
+  }
+
+  private async sendTransactionRequest(
+    signer: Signer,
+    request: TransactionRequest
+  ): Promise<string> {
+    const tx = await signer.sendTransaction(request);
+    const txnReceipt = await tx.wait();
+    if (!txnReceipt) {
+      throw new Error(`transaction: ${tx.hash} failed to mined`);
+    }
+    const status: number | null = txnReceipt.status;
+    const txnHash: string = txnReceipt.hash;
+
+    if (!status) {
+      throw new Error(`transaction: ${txnHash} failed to mined`);
+    }
+
+    return txnHash;
   }
 }

--- a/src/storage/interfaces/state.ts
+++ b/src/storage/interfaces/state.ts
@@ -1,6 +1,15 @@
 import { ZKProof } from '@iden3/js-jwz';
 import { Signer } from 'ethers';
 import { RootInfo, StateInfo, StateProof } from '../entities/state';
+import { Id } from '@iden3/js-iden3-core';
+import { Hash } from '@iden3/js-merkletree';
+
+export interface UserStateTransition {
+  userId: Id;
+  oldUserState: Hash;
+  newUserState: Hash;
+  isOldStateGenesis: boolean;
+}
 
 /**
  * Interface that defines methods for state storage
@@ -32,7 +41,11 @@ export interface IStateStorage {
    * @param {Signer} signer  - signer of transaction
    * @returns `Promise<string>` - transaction identifier
    */
-  publishState(proof: ZKProof, signer: Signer): Promise<string>;
+  publishState(
+    proof: ZKProof | undefined,
+    signer: Signer,
+    userStateTransition?: UserStateTransition
+  ): Promise<string>;
   /**
    * generates proof of inclusion / non-inclusion to global identity state for given identity
    *

--- a/src/storage/interfaces/state.ts
+++ b/src/storage/interfaces/state.ts
@@ -4,11 +4,13 @@ import { RootInfo, StateInfo, StateProof } from '../entities/state';
 import { Id } from '@iden3/js-iden3-core';
 import { Hash } from '@iden3/js-merkletree';
 
-export interface UserStateTransition {
-  userId: Id;
-  oldUserState: Hash;
-  newUserState: Hash;
-  isOldStateGenesis: boolean;
+export interface UserStateTransitionInfo {
+  userId: Id; // Identity id
+  oldUserState: Hash; // Previous identity state
+  newUserState: Hash; // New identity state
+  isOldStateGenesis: boolean; // Is the previous state genesis?
+  methodId: bigint; // State transition method id
+  methodParams: string; // State transition method-specific params
 }
 
 /**
@@ -41,10 +43,17 @@ export interface IStateStorage {
    * @param {Signer} signer  - signer of transaction
    * @returns `Promise<string>` - transaction identifier
    */
-  publishState(
-    proof: ZKProof | undefined,
+  publishState(proof: ZKProof | undefined, signer: Signer): Promise<string>;
+  /**
+   * method to publish state onchain
+   *
+   * @param {Signer} signer  - signer of transaction
+   * @param {UserStateTransitionInfo} userStateTransitionInfo  - user state transition information
+   * @returns `Promise<string>` - transaction identifier
+   */
+  publishStateGeneric(
     signer: Signer,
-    userStateTransition?: UserStateTransition
+    userStateTransitionInfo?: UserStateTransitionInfo
   ): Promise<string>;
   /**
    * generates proof of inclusion / non-inclusion to global identity state for given identity

--- a/src/utils/did-helper.ts
+++ b/src/utils/did-helper.ts
@@ -8,7 +8,7 @@ import { hexToBytes } from './encoding';
 /**
  * Checks if state is genesis state
  *
- * @param {string} did - did
+ * @param {DID} did - did
  * @param {bigint|string} state  - hash on bigInt or hex string format
  * @returns boolean
  */
@@ -27,7 +27,7 @@ export function isGenesisState(did: DID, state: bigint | string): boolean {
 /**
  * Checks if DID is an ethereum identity
  *
- * @param {string} did - did
+ * @param {DID} did - did
  * @returns boolean
  */
 export function isEthereumIdentity(did: DID): boolean {

--- a/src/utils/did-helper.ts
+++ b/src/utils/did-helper.ts
@@ -22,6 +22,24 @@ export function isGenesisState(did: DID, state: bigint | string): boolean {
   return id.bigInt().toString() === idFromState.bigInt().toString();
 }
 
+/**
+ * Checks if DID is an ethereum identity
+ *
+ * @param {string} did - did
+ * @returns boolean
+ */
+export function isEthereumIdentity(did: DID): boolean {
+  const issuerId = DID.idFromDID(did);
+  try {
+    Id.ethAddressFromId(issuerId);
+    // is an ethereum identity
+    return true;
+  } catch {
+    // not an ethereum identity (BabyJubJub or other)
+    return false;
+  }
+}
+
 export const buildVerifierId = (
   address: string,
   info: { method: string; blockchain: string; networkId: string }

--- a/src/utils/did-helper.ts
+++ b/src/utils/did-helper.ts
@@ -3,6 +3,7 @@ import { Id, buildDIDType, genesisFromEthAddress, DID } from '@iden3/js-iden3-co
 import { Hash } from '@iden3/js-merkletree';
 import { DIDResolutionResult, VerificationMethod } from 'did-resolver';
 import { keccak256 } from 'js-sha3';
+import { hexToBytes } from './encoding';
 
 /**
  * Checks if state is genesis state
@@ -87,9 +88,9 @@ export const resolveDIDDocumentAuth = async (
 
 export const buildDIDFromEthPubKey = (didType: Uint8Array, pubKeyEth: string): DID => {
   // Use Keccak-256 hash function to get public key hash
-  const hashOfPublicKey = keccak256(Buffer.from(pubKeyEth, 'hex'));
+  const hashOfPublicKey = keccak256(hexToBytes(pubKeyEth));
   // Convert hash to buffer
-  const ethAddressBuffer = Buffer.from(hashOfPublicKey, 'hex');
+  const ethAddressBuffer = hexToBytes(hashOfPublicKey);
   // Ethereum Address is '0x' concatenated with last 20 bytes
   // of the public key hash
   const ethAddr = ethAddressBuffer.slice(-20);

--- a/tests/credentials/credential-statuses/on-chain-revocation.test.ts
+++ b/tests/credentials/credential-statuses/on-chain-revocation.test.ts
@@ -239,10 +239,8 @@ describe('onchain revocation checks', () => {
       new Iden3OnchainSmtCredentialStatusPublisher(storage)
     );
 
-    const prover = new NativeProver(circuitStorage);
     idWallet = new IdentityWallet(registerKeyProvidersInMemoryKMS(), dataStorage, credWallet, {
-      credentialStatusPublisherRegistry,
-      prover
+      credentialStatusPublisherRegistry
     });
     proofService = new ProofService(idWallet, credWallet, circuitStorage, ethStorage);
   });

--- a/tests/credentials/credential-statuses/on-chain-revocation.test.ts
+++ b/tests/credentials/credential-statuses/on-chain-revocation.test.ts
@@ -303,7 +303,7 @@ describe('onchain revocation checks', () => {
       CredentialStatusType.Iden3OnchainSparseMerkleTreeProof2023
     );
 
-    await proofService.transitState(issuerDID, res.oldTreeState, true, signer);
+    await proofService.transitState(issuerDID, res.oldTreeState, true, dataStorage.states, signer);
 
     const [ctrHexL, rtrHexL, rorTrHexL] = [
       res.newTreeState.claimsRoot.hex(),

--- a/tests/credentials/credential-statuses/on-chain-revocation.test.ts
+++ b/tests/credentials/credential-statuses/on-chain-revocation.test.ts
@@ -24,8 +24,7 @@ import {
   CredentialStatusPublisherRegistry,
   Iden3OnchainSmtCredentialStatusPublisher,
   SDK_EVENTS,
-  MessageBus,
-  NativeProver
+  MessageBus
 } from '../../../src';
 
 import {

--- a/tests/credentials/credential-statuses/on-chain-revocation.test.ts
+++ b/tests/credentials/credential-statuses/on-chain-revocation.test.ts
@@ -24,7 +24,8 @@ import {
   CredentialStatusPublisherRegistry,
   Iden3OnchainSmtCredentialStatusPublisher,
   SDK_EVENTS,
-  MessageBus
+  MessageBus,
+  NativeProver
 } from '../../../src';
 
 import {
@@ -238,8 +239,10 @@ describe('onchain revocation checks', () => {
       new Iden3OnchainSmtCredentialStatusPublisher(storage)
     );
 
+    const prover = new NativeProver(circuitStorage);
     idWallet = new IdentityWallet(registerKeyProvidersInMemoryKMS(), dataStorage, credWallet, {
-      credentialStatusPublisherRegistry
+      credentialStatusPublisherRegistry,
+      prover
     });
     proofService = new ProofService(idWallet, credWallet, circuitStorage, ethStorage);
   });
@@ -300,7 +303,7 @@ describe('onchain revocation checks', () => {
       CredentialStatusType.Iden3OnchainSparseMerkleTreeProof2023
     );
 
-    await proofService.transitState(issuerDID, res.oldTreeState, true, dataStorage.states, signer);
+    await proofService.transitState(issuerDID, res.oldTreeState, true, signer);
 
     const [ctrHexL, rtrHexL, rorTrHexL] = [
       res.newTreeState.claimsRoot.hex(),

--- a/tests/credentials/credential-statuses/on-chain-revocation.test.ts
+++ b/tests/credentials/credential-statuses/on-chain-revocation.test.ts
@@ -29,7 +29,7 @@ import {
 
 import {
   createIdentity,
-  registerBJJIntoInMemoryKMS,
+  registerKeyProvidersInMemoryKMS,
   STATE_CONTRACT,
   RPC_URL,
   WALLET_KEY,
@@ -238,7 +238,7 @@ describe('onchain revocation checks', () => {
       new Iden3OnchainSmtCredentialStatusPublisher(storage)
     );
 
-    idWallet = new IdentityWallet(registerBJJIntoInMemoryKMS(), dataStorage, credWallet, {
+    idWallet = new IdentityWallet(registerKeyProvidersInMemoryKMS(), dataStorage, credWallet, {
       credentialStatusPublisherRegistry
     });
     proofService = new ProofService(idWallet, credWallet, circuitStorage, ethStorage);

--- a/tests/credentials/credential-statuses/rhs.test.ts
+++ b/tests/credentials/credential-statuses/rhs.test.ts
@@ -37,6 +37,9 @@ describe('rhs', () => {
     publishState: async () => {
       return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
     },
+    publishStateGeneric: async () => {
+      return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+    },
     getGISTProof: (): Promise<StateProof> => {
       return Promise.resolve({
         root: 0n,
@@ -79,6 +82,9 @@ describe('rhs', () => {
     publishState: async () => {
       return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
     },
+    publishStateGeneric: async () => {
+      return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+    },
     getGISTProof: (): Promise<StateProof> => {
       return Promise.resolve({
         root: 0n,
@@ -118,6 +124,9 @@ describe('rhs', () => {
       throw new Error(VerifiableConstants.ERRORS.IDENTITY_DOES_NOT_EXIST);
     },
     publishState: async () => {
+      return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+    },
+    publishStateGeneric: async () => {
       return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
     },
     getGISTProof: (): Promise<StateProof> => {

--- a/tests/credentials/credential-statuses/sparse-merkle-tree-proof.test.ts
+++ b/tests/credentials/credential-statuses/sparse-merkle-tree-proof.test.ts
@@ -8,7 +8,7 @@ import {
   SEED_USER,
   createIdentity,
   getInMemoryDataStorage,
-  registerBJJIntoInMemoryKMS
+  registerKeyProvidersInMemoryKMS
 } from '../../helpers';
 import { DID } from '@iden3/js-iden3-core';
 import fetchMock from '@gr2m/fetch-mock';
@@ -26,7 +26,7 @@ describe('SparseMerkleTreeProof', () => {
   const issuerWalletUrl = 'https://issuer.com';
 
   beforeEach(async () => {
-    const kms = registerBJJIntoInMemoryKMS();
+    const kms = registerKeyProvidersInMemoryKMS();
     dataStorage = getInMemoryDataStorage(MOCK_STATE_STORAGE);
 
     credWallet = new CredentialWallet(dataStorage);

--- a/tests/credentials/credential-validation.test.ts
+++ b/tests/credentials/credential-validation.test.ts
@@ -50,6 +50,9 @@ const mockStateStorage: IStateStorage = {
   publishState: async () => {
     return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
   },
+  publishStateGeneric: async () => {
+    return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+  },
   getGISTProof: (): Promise<StateProof> => {
     return Promise.resolve({
       root: 0n,

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -39,7 +39,8 @@ import {
   W3CCredential,
   Sec256k1Provider,
   StateInfo,
-  hexToBytes
+  hexToBytes,
+  NativeProver
 } from '../../src';
 import { Token } from '@iden3/js-jwz';
 import { Blockchain, DID, DidMethod, NetworkId } from '@iden3/js-iden3-core';
@@ -300,13 +301,7 @@ describe('auth', () => {
       (dataStorage.states as EthStateStorage).provider
     );
 
-    const txId = await proofService.transitState(
-      issuerDID,
-      res.oldTreeState,
-      true,
-      dataStorage.states,
-      ethSigner
-    );
+    const txId = await proofService.transitState(issuerDID, res.oldTreeState, true, ethSigner);
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       issuerDID,
@@ -423,8 +418,7 @@ describe('auth', () => {
         id: RHS_URL
       },
       keyType: KmsKeyType.Secp256k1,
-      ethSigner,
-      proofService
+      ethSigner
     });
     expect(issuerAuthCredential).not.to.be.undefined;
 
@@ -470,13 +464,7 @@ describe('auth', () => {
     const res = await idWallet.addCredentialsToMerkleTree([employeeCred], didIssuer);
     await idWallet.publishStateToRHS(didIssuer, RHS_URL);
 
-    const txId = await proofService.transitState(
-      didIssuer,
-      res.oldTreeState,
-      true,
-      dataStorage.states,
-      ethSigner
-    );
+    const txId = await proofService.transitState(didIssuer, res.oldTreeState, true, ethSigner);
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       didIssuer,
@@ -628,7 +616,9 @@ describe('auth', () => {
       new RHSResolver(dataStorage.states)
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
-    idWallet = new IdentityWallet(kms, dataStorage, credWallet);
+
+    const prover = new NativeProver(circuitStorage);
+    idWallet = new IdentityWallet(kms, dataStorage, credWallet, { prover });
 
     proofService = new ProofService(idWallet, credWallet, circuitStorage, dataStorage.states, {
       ipfsNodeURL: IPFS_URL
@@ -670,8 +660,7 @@ describe('auth', () => {
         id: RHS_URL
       },
       keyType: KmsKeyType.Secp256k1,
-      ethSigner,
-      proofService
+      ethSigner
     });
     expect(issuerAuthCredential).not.to.be.undefined;
 
@@ -717,13 +706,7 @@ describe('auth', () => {
     const res = await idWallet.addCredentialsToMerkleTree([employeeCred], didIssuer);
     await idWallet.publishStateToRHS(didIssuer, RHS_URL);
 
-    const txId = await proofService.transitState(
-      didIssuer,
-      res.oldTreeState,
-      false,
-      dataStorage.states,
-      ethSigner
-    );
+    const txId = await proofService.transitState(didIssuer, res.oldTreeState, false, ethSigner);
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       didIssuer,

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -38,7 +38,8 @@ import {
   InMemoryMerkleTreeStorage,
   W3CCredential,
   Sec256k1Provider,
-  StateInfo
+  StateInfo,
+  hexToBytes
 } from '../../src';
 import { Token } from '@iden3/js-jwz';
 import { Blockchain, DID, DidMethod, NetworkId } from '@iden3/js-iden3-core';
@@ -663,7 +664,7 @@ describe('auth', () => {
       method: DidMethod.PolygonId,
       blockchain: Blockchain.Polygon,
       networkId: NetworkId.Amoy,
-      seed: Buffer.from(WALLET_KEY, 'hex'),
+      seed: hexToBytes(WALLET_KEY),
       revocationOpts: {
         type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
         id: RHS_URL

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -39,8 +39,7 @@ import {
   W3CCredential,
   Sec256k1Provider,
   StateInfo,
-  hexToBytes,
-  NativeProver
+  hexToBytes
 } from '../../src';
 import { Token } from '@iden3/js-jwz';
 import { Blockchain, DID, DidMethod, NetworkId } from '@iden3/js-iden3-core';

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -408,18 +408,18 @@ describe('auth', () => {
       (dataStorage.states as EthStateStorage).provider
     );
 
-    const { did: didIssuer, credential: issuerAuthCredential } = await idWallet.createIdentity({
-      method: DidMethod.PolygonId,
-      blockchain: Blockchain.Polygon,
-      networkId: NetworkId.Mumbai,
-      seed: SEED_ISSUER,
-      revocationOpts: {
-        type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
-        id: RHS_URL
-      },
-      keyType: KmsKeyType.Secp256k1,
-      ethSigner
-    });
+    const { did: didIssuer, credential: issuerAuthCredential } =
+      await idWallet.createEthereumBasedIdentity({
+        method: DidMethod.PolygonId,
+        blockchain: Blockchain.Polygon,
+        networkId: NetworkId.Mumbai,
+        seed: SEED_ISSUER,
+        revocationOpts: {
+          type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
+          id: RHS_URL
+        },
+        ethSigner
+      });
     expect(issuerAuthCredential).not.to.be.undefined;
 
     const profileDID = await idWallet.createProfile(userDID, 777, didIssuer.string());
@@ -650,18 +650,18 @@ describe('auth', () => {
       (dataStorage.states as EthStateStorage).provider
     );
 
-    const { did: didIssuer, credential: issuerAuthCredential } = await idWallet.createIdentity({
-      method: DidMethod.PolygonId,
-      blockchain: Blockchain.Polygon,
-      networkId: NetworkId.Amoy,
-      seed: hexToBytes(WALLET_KEY),
-      revocationOpts: {
-        type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
-        id: RHS_URL
-      },
-      keyType: KmsKeyType.Secp256k1,
-      ethSigner
-    });
+    const { did: didIssuer, credential: issuerAuthCredential } =
+      await idWallet.createEthereumBasedIdentity({
+        method: DidMethod.PolygonId,
+        blockchain: Blockchain.Polygon,
+        networkId: NetworkId.Amoy,
+        seed: hexToBytes(WALLET_KEY),
+        revocationOpts: {
+          type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
+          id: RHS_URL
+        },
+        ethSigner
+      });
     expect(issuerAuthCredential).not.to.be.undefined;
 
     const profileDID = await idWallet.createProfile(didUser, 777, didIssuer.string());

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -405,7 +405,7 @@ describe('auth', () => {
     expect(token).to.be.a('object');
   });
 
-  it.only('auth flow identity (profile) with ethereum identity issuer with circuits V3', async () => {
+  it('auth flow identity (profile) with ethereum identity issuer with circuits V3', async () => {
     const ethSigner = new ethers.Wallet(
       WALLET_KEY,
       (dataStorage.states as EthStateStorage).provider

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -88,8 +88,7 @@ describe('auth', () => {
       new RHSResolver(dataStorage.states)
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
-    const prover = new NativeProver(circuitStorage);
-    idWallet = new IdentityWallet(kms, dataStorage, credWallet, { prover });
+    idWallet = new IdentityWallet(kms, dataStorage, credWallet);
 
     proofService = new ProofService(idWallet, credWallet, circuitStorage, MOCK_STATE_STORAGE, {
       ipfsNodeURL: IPFS_URL
@@ -632,8 +631,7 @@ describe('auth', () => {
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
 
-    const prover = new NativeProver(circuitStorage);
-    idWallet = new IdentityWallet(kms, dataStorage, credWallet, { prover });
+    idWallet = new IdentityWallet(kms, dataStorage, credWallet);
 
     proofService = new ProofService(idWallet, credWallet, circuitStorage, dataStorage.states, {
       ipfsNodeURL: IPFS_URL

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -424,9 +424,7 @@ describe('auth', () => {
           type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
           id: RHS_URL
         },
-        ethereumBasedIdentityOpts: {
-          ethSigner
-        }
+        ethSigner
       });
     expect(issuerAuthCredential).not.to.be.undefined;
 
@@ -673,9 +671,7 @@ describe('auth', () => {
           type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
           id: RHS_URL
         },
-        ethereumBasedIdentityOpts: {
-          ethSigner
-        }
+        ethSigner
       });
     expect(issuerAuthCredential).not.to.be.undefined;
 

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -88,7 +88,8 @@ describe('auth', () => {
       new RHSResolver(dataStorage.states)
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
-    idWallet = new IdentityWallet(kms, dataStorage, credWallet);
+    const prover = new NativeProver(circuitStorage);
+    idWallet = new IdentityWallet(kms, dataStorage, credWallet, { prover });
 
     proofService = new ProofService(idWallet, credWallet, circuitStorage, MOCK_STATE_STORAGE, {
       ipfsNodeURL: IPFS_URL
@@ -301,7 +302,13 @@ describe('auth', () => {
       (dataStorage.states as EthStateStorage).provider
     );
 
-    const txId = await proofService.transitState(issuerDID, res.oldTreeState, true, ethSigner);
+    const txId = await proofService.transitState(
+      issuerDID,
+      res.oldTreeState,
+      true,
+      dataStorage.states,
+      ethSigner
+    );
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       issuerDID,
@@ -418,7 +425,9 @@ describe('auth', () => {
           type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
           id: RHS_URL
         },
-        ethSigner
+        ethereumBasedIdentityOpts: {
+          ethSigner
+        }
       });
     expect(issuerAuthCredential).not.to.be.undefined;
 
@@ -464,7 +473,13 @@ describe('auth', () => {
     const res = await idWallet.addCredentialsToMerkleTree([employeeCred], didIssuer);
     await idWallet.publishStateToRHS(didIssuer, RHS_URL);
 
-    const txId = await proofService.transitState(didIssuer, res.oldTreeState, true, ethSigner);
+    const txId = await proofService.transitState(
+      didIssuer,
+      res.oldTreeState,
+      true,
+      dataStorage.states,
+      ethSigner
+    );
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       didIssuer,
@@ -660,7 +675,9 @@ describe('auth', () => {
           type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
           id: RHS_URL
         },
-        ethSigner
+        ethereumBasedIdentityOpts: {
+          ethSigner
+        }
       });
     expect(issuerAuthCredential).not.to.be.undefined;
 
@@ -706,7 +723,13 @@ describe('auth', () => {
     const res = await idWallet.addCredentialsToMerkleTree([employeeCred], didIssuer);
     await idWallet.publishStateToRHS(didIssuer, RHS_URL);
 
-    const txId = await proofService.transitState(didIssuer, res.oldTreeState, false, ethSigner);
+    const txId = await proofService.transitState(
+      didIssuer,
+      res.oldTreeState,
+      false,
+      dataStorage.states,
+      ethSigner
+    );
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       didIssuer,

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -2071,7 +2071,7 @@ describe('auth', () => {
   it('key rotation use case', async () => {
     const claimReq: CredentialRequest = {
       credentialSchema:
-        'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/kyc-nonmerklized.json',
+        'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v4.json',
       type: 'KYCAgeCredential',
       credentialSubject: {
         id: userDID.string(),
@@ -2091,18 +2091,19 @@ describe('auth', () => {
 
     const proofReq: ZeroKnowledgeProofRequest = {
       id: 1,
-      circuitId: CircuitId.AtomicQuerySigV2,
+      circuitId: CircuitId.AtomicQueryV3,
       optional: false,
       query: {
         allowedIssuers: ['*'],
         type: claimReq.type,
         context:
-          'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-nonmerklized.jsonld',
+          'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v4.jsonld',
         credentialSubject: {
           documentType: {
             $eq: 99
           }
-        }
+        },
+        proofType: ProofType.BJJSignature
       }
     };
 

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -2206,6 +2206,10 @@ describe('auth', () => {
     );
     expect(issuerAuthCredential2).to.be.deep.equal(credential2);
 
+    // check we can issue new credential with k2
+    const issuerCred2 = await idWallet.issueCredential(issuerDID, claimReq);
+    expect(issuerCred2).to.be.not.undefined;
+
     const treesModel2 = await idWallet.getDIDTreeModel(issuerDID);
     const [ctrHex2, rtrHex2, rorTrHex2] = await Promise.all([
       treesModel2.claimsTree.root(),
@@ -2227,6 +2231,11 @@ describe('auth', () => {
 
     // check that we don't have auth credentials now
     await expect(idWallet.getActualAuthCredential(issuerDID)).to.rejectedWith(
+      'no auth credentials found'
+    );
+
+    // check that we can't issue new credential
+    await expect(idWallet.issueCredential(issuerDID, claimReq)).to.rejectedWith(
       'no auth credentials found'
     );
 

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -34,7 +34,7 @@ import * as uuid from 'uuid';
 import {
   MOCK_STATE_STORAGE,
   getInMemoryDataStorage,
-  registerBJJIntoInMemoryKMS,
+  registerKeyProvidersInMemoryKMS,
   IPFS_URL,
   getPackageMgr,
   createIdentity,
@@ -57,7 +57,7 @@ describe('auth', () => {
   let issuerDID: DID;
 
   beforeEach(async () => {
-    const kms = registerBJJIntoInMemoryKMS();
+    const kms = registerKeyProvidersInMemoryKMS();
     dataStorage = getInMemoryDataStorage(MOCK_STATE_STORAGE);
     const circuitStorage = new FSCircuitStorage({
       dirname: path.join(__dirname, '../proofs/testdata')
@@ -259,6 +259,163 @@ describe('auth', () => {
       type: 'KYCEmployee',
       credentialSubject: {
         id: profileDID.string(),
+        ZKPexperiance: true,
+        hireDate: '2023-12-11',
+        position: 'boss',
+        salary: 200,
+        documentType: 1
+      },
+      revocationOpts: {
+        type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
+        id: RHS_URL
+      }
+    };
+    const employeeCred = await idWallet.issueCredential(issuerDID, employeeCredRequest);
+
+    await credWallet.saveAll([employeeCred, issuerCred]);
+
+    const res = await idWallet.addCredentialsToMerkleTree([employeeCred], issuerDID);
+    await idWallet.publishStateToRHS(issuerDID, RHS_URL);
+
+    const ethSigner = new ethers.Wallet(
+      WALLET_KEY,
+      (dataStorage.states as EthStateStorage).provider
+    );
+
+    const txId = await proofService.transitState(
+      issuerDID,
+      res.oldTreeState,
+      true,
+      dataStorage.states,
+      ethSigner
+    );
+
+    const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
+      issuerDID,
+      res.credentials,
+      txId
+    );
+
+    await credWallet.saveAll(credsWithIden3MTPProof);
+
+    const proofReqs: ZeroKnowledgeProofRequest[] = [
+      {
+        id: 1,
+        circuitId: CircuitId.AtomicQueryV3,
+        optional: false,
+        query: {
+          proofType: ProofType.BJJSignature,
+          allowedIssuers: ['*'],
+          type: 'KYCAgeCredential',
+          context:
+            'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-nonmerklized.jsonld',
+          credentialSubject: {
+            documentType: {
+              $eq: 99
+            }
+          }
+        }
+      },
+      {
+        id: 2,
+        circuitId: CircuitId.LinkedMultiQuery10,
+        optional: false,
+        query: {
+          groupId: 1,
+          proofType: ProofType.Iden3SparseMerkleTreeProof,
+          allowedIssuers: ['*'],
+          type: 'KYCEmployee',
+          context:
+            'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v101.json-ld',
+          credentialSubject: {
+            documentType: {
+              $eq: 1
+            },
+            position: {
+              $eq: 'boss',
+              $ne: 'employee'
+            }
+          }
+        }
+      },
+      {
+        id: 3,
+        circuitId: CircuitId.AtomicQueryV3,
+        optional: false,
+        query: {
+          groupId: 1,
+          proofType: ProofType.BJJSignature,
+          allowedIssuers: ['*'],
+          type: 'KYCEmployee',
+          context:
+            'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v101.json-ld',
+          credentialSubject: {
+            hireDate: {
+              $eq: '2023-12-11'
+            }
+          }
+        },
+        params: {
+          nullifierSessionId: '12345'
+        }
+      }
+    ];
+
+    const authReqBody: AuthorizationRequestMessageBody = {
+      callbackUrl: 'http://localhost:8080/callback?id=1234442-123123-123123',
+      reason: 'reason',
+      message: 'mesage',
+      did_doc: {},
+      scope: proofReqs
+    };
+
+    const id = uuid.v4();
+    const authReq: AuthorizationRequestMessage = {
+      id,
+      typ: PROTOCOL_CONSTANTS.MediaType.PlainMessage,
+      type: PROTOCOL_CONSTANTS.PROTOCOL_MESSAGE_TYPE.AUTHORIZATION_REQUEST_MESSAGE_TYPE,
+      thid: id,
+      body: authReqBody,
+      from: issuerDID.string()
+    };
+
+    const msgBytes = byteEncoder.encode(JSON.stringify(authReq));
+    const authRes = await authHandler.handleAuthorizationRequest(userDID, msgBytes);
+    // console.log(JSON.stringify(authRes.authResponse));
+    const tokenStr = authRes.token;
+    // console.log(tokenStr);
+    expect(tokenStr).to.be.a('string');
+    const token = await Token.parse(tokenStr);
+    expect(token).to.be.a('object');
+  });
+
+  it('auth flow Ethereum identity with circuits V3', async () => {
+    const { did: ethereumDID } = await createIdentity(idWallet, {
+      seed: SEED_USER
+    });
+
+    const claimReq: CredentialRequest = {
+      credentialSchema:
+        'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/kyc-nonmerklized.json',
+      type: 'KYCAgeCredential',
+      credentialSubject: {
+        id: ethereumDID.string(),
+        birthday: 19960424,
+        documentType: 99
+      },
+      expiration: 2793526400,
+      revocationOpts: {
+        type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
+        id: RHS_URL
+      }
+    };
+    const issuerCred = await idWallet.issueCredential(issuerDID, claimReq);
+    const employeeCredRequest: CredentialRequest = {
+      credentialSchema:
+        'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCEmployee-v101.json',
+      type: 'KYCEmployee',
+      credentialSubject: {
+        id: ethereumDID.string(),
         ZKPexperiance: true,
         hireDate: '2023-12-11',
         position: 'boss',

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -625,9 +625,8 @@ describe('auth', () => {
     };
 
     const msgBytes = byteEncoder.encode(JSON.stringify(authReq));
-    console.log('authReq', authReq);
     const authRes = await authHandler.handleAuthorizationRequest(didUser, msgBytes);
-    console.log('authRes', JSON.stringify(authRes.authResponse));
+    // console.log('authRes', JSON.stringify(authRes.authResponse));
     const tokenStr = authRes.token;
     // console.log(tokenStr);
     expect(tokenStr).to.be.a('string');

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -2068,7 +2068,7 @@ describe('auth', () => {
     expect(token).to.be.a('object');
   });
 
-  it.only('key rotation use case', async () => {
+  it('key rotation use case', async () => {
     const claimReq: CredentialRequest = {
       credentialSchema:
         'https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/kyc-nonmerklized.json',

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -24,7 +24,8 @@ import {
   createAuthorizationRequestWithMessage,
   AuthorizationResponseMessage,
   ZeroKnowledgeProofResponse,
-  ProofType
+  ProofType,
+  KmsKeyType
 } from '../../src';
 import { Token } from '@iden3/js-jwz';
 import { DID } from '@iden3/js-iden3-core';
@@ -391,7 +392,8 @@ describe('auth', () => {
 
   it('auth flow Ethereum identity with circuits V3', async () => {
     const { did: ethereumDID } = await createIdentity(idWallet, {
-      seed: SEED_USER
+      seed: SEED_USER,
+      keyType: KmsKeyType.Secp256k1
     });
 
     const claimReq: CredentialRequest = {
@@ -537,7 +539,7 @@ describe('auth', () => {
     };
 
     const msgBytes = byteEncoder.encode(JSON.stringify(authReq));
-    const authRes = await authHandler.handleAuthorizationRequest(userDID, msgBytes);
+    const authRes = await authHandler.handleAuthorizationRequest(ethereumDID, msgBytes);
     // console.log(JSON.stringify(authRes.authResponse));
     const tokenStr = authRes.token;
     // console.log(tokenStr);

--- a/tests/handlers/contract-request.test.ts
+++ b/tests/handlers/contract-request.test.ts
@@ -82,6 +82,9 @@ describe('contract-request', () => {
     publishState: async () => {
       return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
     },
+    publishStateGeneric: async () => {
+      return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+    },
     getGISTProof: (): Promise<StateProof> => {
       return Promise.resolve({
         root: 0n,

--- a/tests/handlers/fetch.test.ts
+++ b/tests/handlers/fetch.test.ts
@@ -28,7 +28,7 @@ import {
   createIdentity,
   getInMemoryDataStorage,
   getPackageMgr,
-  registerBJJIntoInMemoryKMS
+  registerKeyProvidersInMemoryKMS
 } from '../helpers';
 
 import * as uuid from 'uuid';
@@ -112,7 +112,7 @@ describe('fetch', () => {
 }`;
 
   beforeEach(async () => {
-    const kms = registerBJJIntoInMemoryKMS();
+    const kms = registerKeyProvidersInMemoryKMS();
     dataStorage = getInMemoryDataStorage(MOCK_STATE_STORAGE);
     const circuitStorage = new FSCircuitStorage({
       dirname: path.join(__dirname, '../proofs/testdata')

--- a/tests/handlers/revocation-status.test.ts
+++ b/tests/handlers/revocation-status.test.ts
@@ -19,7 +19,7 @@ import {
   MOCK_STATE_STORAGE,
   getInMemoryDataStorage,
   getPackageMgr,
-  registerBJJIntoInMemoryKMS,
+  registerKeyProvidersInMemoryKMS,
   createIdentity,
   SEED_USER,
   SEED_ISSUER
@@ -35,7 +35,7 @@ describe('revocation status', () => {
   let idWallet: IdentityWallet;
 
   beforeEach(async () => {
-    const kms = registerBJJIntoInMemoryKMS();
+    const kms = registerKeyProvidersInMemoryKMS();
     const dataStorage = getInMemoryDataStorage(MOCK_STATE_STORAGE);
     const circuitStorage = new FSCircuitStorage({
       dirname: path.join(__dirname, '../proofs/testdata')

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -47,8 +47,10 @@ export const createIdentity = async (
   wallet: IIdentityWallet,
   opts?: Partial<IdentityCreationOptions>
 ) => {
+  // For testing in Mumbai should be "DidMethod.PolygonId" for the State contract already deployed
+  // Otherwise it will throw an error "msg.sender is not owner of the identity" when checking the Id from the sender
   return await wallet.createIdentity({
-    method: DidMethod.Iden3,
+    method: DidMethod.PolygonId,
     blockchain: Blockchain.Polygon,
     networkId: NetworkId.Amoy,
     seed: SEED_ISSUER,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -81,6 +81,9 @@ export const MOCK_STATE_STORAGE: IStateStorage = {
   publishState: async () => {
     return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
   },
+  publishStateGeneric: async () => {
+    return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+  },
   getGISTProof: (): Promise<StateProof> => {
     return Promise.resolve({
       root: 0n,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -60,6 +60,23 @@ export const createIdentity = async (
   });
 };
 
+export const createEthereumBasedIdentity = async (
+  wallet: IIdentityWallet,
+  opts?: Partial<IdentityCreationOptions>
+) => {
+  return await wallet.createEthereumBasedIdentity({
+    method: DidMethod.Iden3,
+    blockchain: Blockchain.Polygon,
+    networkId: NetworkId.Amoy,
+    seed: SEED_ISSUER,
+    revocationOpts: {
+      type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
+      id: RHS_URL
+    },
+    ...opts
+  });
+};
+
 export const MOCK_STATE_STORAGE: IStateStorage = {
   getLatestStateById: async () => {
     throw new Error(VerifiableConstants.ERRORS.IDENTITY_DOES_NOT_EXIST);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -6,6 +6,7 @@ import {
   CredentialStatusType,
   CredentialStorage,
   DataPrepareHandlerFunc,
+  EthereumBasedIdentityCreationOptions,
   IIdentityWallet,
   IPackageManager,
   IStateStorage,
@@ -62,7 +63,7 @@ export const createIdentity = async (
 
 export const createEthereumBasedIdentity = async (
   wallet: IIdentityWallet,
-  opts?: Partial<IdentityCreationOptions>
+  opts?: Partial<EthereumBasedIdentityCreationOptions>
 ) => {
   return await wallet.createEthereumBasedIdentity({
     method: DidMethod.Iden3,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -22,6 +22,7 @@ import {
   Profile,
   ProvingParams,
   RootInfo,
+  Sec256k1Provider,
   StateProof,
   StateVerificationFunc,
   VerifiableConstants,
@@ -104,11 +105,13 @@ export const MOCK_STATE_STORAGE: IStateStorage = {
   }
 };
 
-export const registerBJJIntoInMemoryKMS = (): KMS => {
+export const registerKeyProvidersInMemoryKMS = (): KMS => {
   const memoryKeyStore = new InMemoryPrivateKeyStore();
   const bjjProvider = new BjjProvider(KmsKeyType.BabyJubJub, memoryKeyStore);
   const kms = new KMS();
   kms.registerKeyProvider(KmsKeyType.BabyJubJub, bjjProvider);
+  const sec256k1Provider = new Sec256k1Provider(KmsKeyType.Secp256k1, memoryKeyStore);
+  kms.registerKeyProvider(KmsKeyType.Secp256k1, sec256k1Provider);
   return kms;
 };
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -47,10 +47,8 @@ export const createIdentity = async (
   wallet: IIdentityWallet,
   opts?: Partial<IdentityCreationOptions>
 ) => {
-  // For testing in Mumbai should be "DidMethod.PolygonId" for the State contract already deployed
-  // Otherwise it will throw an error "msg.sender is not owner of the identity" when checking the Id from the sender
   return await wallet.createIdentity({
-    method: DidMethod.PolygonId,
+    method: DidMethod.Iden3,
     blockchain: Blockchain.Polygon,
     networkId: NetworkId.Amoy,
     seed: SEED_ISSUER,

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -187,7 +187,9 @@ describe('identity', () => {
     const ethSigner = new Wallet(WALLET_KEY, (dataStorage.states as EthStateStorage).provider);
 
     const { did, credential } = await createEthereumBasedIdentity(idWallet, {
-      ethSigner
+      ethereumBasedIdentityOpts: {
+        ethSigner
+      }
     });
 
     expect(did.string()).to.equal(

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import path from 'path';
 import {
   IdentityWallet,
   byteEncoder,
@@ -10,7 +11,11 @@ import {
   CredentialStatusResolverRegistry,
   RHSResolver,
   CredentialStatusType,
-  EthStateStorage
+  EthStateStorage,
+  FSCircuitStorage,
+  NativeProver,
+  Iden3SparseMerkleTreeProof,
+  BJJSignatureProof2021
 } from '../../src';
 import {
   MOCK_STATE_STORAGE,
@@ -196,5 +201,61 @@ describe('identity', () => {
     );
 
     expect((await claimsTree.root()).bigInt()).not.to.equal(0);
+  });
+
+  it('add auth bjj credential', async () => {
+    const { did, credential } = await createIdentity(idWallet);
+    expect(did.string()).to.equal(expectedDID);
+
+    const proof = await idWallet.generateCredentialMtp(did, credential);
+    expect(proof.proof.existence).to.equal(true);
+
+    const circuitStorage = new FSCircuitStorage({
+      dirname: path.join(__dirname, '../proofs/testdata')
+    });
+    const prover = new NativeProver(circuitStorage);
+
+    const ethSigner = new Wallet(WALLET_KEY, (dataStorage.states as EthStateStorage).provider);
+    const opts = {
+      seed: SEED_USER,
+      revocationOpts: {
+        type: CredentialStatusType.Iden3ReverseSparseMerkleTreeProof,
+        id: RHS_URL
+      }
+    };
+
+    const treesModel = await idWallet.getDIDTreeModel(did);
+    const [ctrHex, rtrHex, rorTrHex] = await Promise.all([
+      treesModel.claimsTree.root(),
+      treesModel.revocationTree.root(),
+      treesModel.rootsTree.root()
+    ]);
+
+    const oldTreeState = {
+      state: treesModel.state,
+      claimsRoot: ctrHex,
+      revocationRoot: rtrHex,
+      rootOfRoots: rorTrHex
+    };
+
+    expect(credential?.proof).not.to.be.undefined;
+    expect((credential?.proof as unknown[])[0]).to.instanceOf(Iden3SparseMerkleTreeProof);
+    expect((credential?.proof as unknown[]).length).to.equal(1);
+
+    const credential2 = await idWallet.addBJJAuthCredential(
+      did,
+      oldTreeState,
+      false,
+      ethSigner,
+      opts,
+      prover
+    );
+    expect(credential2?.proof).not.to.be.undefined;
+    expect((credential2?.proof as unknown[]).length).to.equal(2);
+    expect((credential2?.proof as unknown[])[0]).to.instanceOf(BJJSignatureProof2021);
+    expect((credential2?.proof as unknown[])[1]).to.instanceOf(Iden3SparseMerkleTreeProof);
+
+    const proof2 = await idWallet.generateCredentialMtp(did, credential2);
+    expect(proof2.proof.existence).to.equal(true);
   });
 });

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -173,7 +173,7 @@ describe('identity', () => {
     const { did, credential } = await createIdentity(idWallet, { keyType: KmsKeyType.Secp256k1 });
 
     expect(did.string()).to.equal(
-      'did:iden3:polygon:mumbai:wuL2hHjCC1L1XzC2bdyFwU5KxYGdkXiA8ChDSM2dF'
+      'did:iden3:polygon:mumbai:wuL2hHjCC1LQArvVpwTkW6KeJNxAv9PfhCnMK4rnX'
     );
     const dbCred = await dataStorage.credential.findCredentialById(credential.id);
     expect(credential).to.deep.equal(dbCred);

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -318,8 +318,7 @@ describe('identity', () => {
     const afterRevokeProofNRcredential = await idWallet.generateNonRevocationMtp(did, credential);
     expect(afterRevokeProofNRcredential.proof.existence).to.equal(true);
 
-    // credential2 was generated with sigproof from credential, so it should be revoked as well
     const afterRevokeProofNRcredential2 = await idWallet.generateNonRevocationMtp(did, credential2);
-    expect(afterRevokeProofNRcredential2.proof.existence).to.equal(true);
+    expect(afterRevokeProofNRcredential2.proof.existence).to.equal(false);
   });
 });

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -11,7 +11,6 @@ import {
   CredentialStatusResolverRegistry,
   RHSResolver,
   CredentialStatusType,
-  KmsKeyType,
   FSCircuitStorage,
   EthStateStorage,
   NativeProver
@@ -23,7 +22,8 @@ import {
   RHS_URL,
   getInMemoryDataStorage,
   registerKeyProvidersInMemoryKMS,
-  WALLET_KEY
+  WALLET_KEY,
+  createEthereumBasedIdentity
 } from '../helpers';
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
@@ -186,15 +186,16 @@ describe('identity', () => {
   it('createIdentity Secp256k1', async () => {
     const ethSigner = new Wallet(WALLET_KEY, (dataStorage.states as EthStateStorage).provider);
 
-    const { did, credential } = await createIdentity(idWallet, {
-      keyType: KmsKeyType.Secp256k1,
+    const { did, credential } = await createEthereumBasedIdentity(idWallet, {
       ethSigner
     });
 
     expect(did.string()).to.equal(
       'did:iden3:polygon:amoy:x6x5sor7zpxsu478u36QvEgaRUfPjmzqFo5PHHzbM'
     );
-    const dbCred = await dataStorage.credential.findCredentialById(credential.id);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const dbCred = await dataStorage.credential.findCredentialById(credential!.id);
     expect(credential).to.deep.equal(dbCred);
 
     const claimsTree = await dataStorage.mt.getMerkleTreeByIdentifierAndType(

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import path from 'path';
 import {
   IdentityWallet,
   byteEncoder,
@@ -10,7 +11,9 @@ import {
   CredentialStatusResolverRegistry,
   RHSResolver,
   CredentialStatusType,
-  KmsKeyType
+  KmsKeyType,
+  ProofService,
+  FSCircuitStorage
 } from '../../src';
 import {
   MOCK_STATE_STORAGE,
@@ -18,7 +21,8 @@ import {
   createIdentity,
   RHS_URL,
   getInMemoryDataStorage,
-  registerKeyProvidersInMemoryKMS
+  registerKeyProvidersInMemoryKMS,
+  IPFS_URL
 } from '../helpers';
 import { expect } from 'chai';
 
@@ -170,7 +174,24 @@ describe('identity', () => {
   });
 
   it('createIdentity Secp256k1', async () => {
-    const { did, credential } = await createIdentity(idWallet, { keyType: KmsKeyType.Secp256k1 });
+    const circuitStorage = new FSCircuitStorage({
+      dirname: path.join(__dirname, '../proofs/testdata')
+    });
+
+    const proofService = new ProofService(
+      idWallet,
+      credWallet,
+      circuitStorage,
+      dataStorage.states,
+      {
+        ipfsNodeURL: IPFS_URL
+      }
+    );
+
+    const { did, credential } = await createIdentity(idWallet, {
+      keyType: KmsKeyType.Secp256k1,
+      proofService
+    });
 
     expect(did.string()).to.equal(
       'did:iden3:polygon:amoy:x6x5sor7zpxsu478u36QvEgaRUfPjmzqFo5PHHzbM'

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -65,14 +65,7 @@ describe('identity', () => {
       new RHSResolver(dataStorage.states)
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
-    const circuitStorage = new FSCircuitStorage({
-      dirname: path.join(__dirname, '../proofs/testdata')
-    });
-
-    const prover = new NativeProver(circuitStorage);
-    idWallet = new IdentityWallet(registerKeyProvidersInMemoryKMS(), dataStorage, credWallet, {
-      prover
-    });
+    idWallet = new IdentityWallet(registerKeyProvidersInMemoryKMS(), dataStorage, credWallet);
   });
 
   it('createIdentity', async () => {

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -173,7 +173,7 @@ describe('identity', () => {
     const { did, credential } = await createIdentity(idWallet, { keyType: KmsKeyType.Secp256k1 });
 
     expect(did.string()).to.equal(
-      'did:iden3:polygon:mumbai:wuL2hHjCC1LQArvVpwTkW6KeJNxAv9PfhCnMK4rnX'
+      'did:iden3:polygon:amoy:x6x5sor7zpxsu478u36QvEgaRUfPjmzqFo5PHHzbM'
     );
     const dbCred = await dataStorage.credential.findCredentialById(credential.id);
     expect(credential).to.deep.equal(dbCred);

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -173,9 +173,7 @@ describe('identity', () => {
     const ethSigner = new Wallet(WALLET_KEY, (dataStorage.states as EthStateStorage).provider);
 
     const { did, credential } = await createEthereumBasedIdentity(idWallet, {
-      ethereumBasedIdentityOpts: {
-        ethSigner
-      }
+      ethSigner
     });
 
     expect(did.string()).to.equal(

--- a/tests/identity/id.test.ts
+++ b/tests/identity/id.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import path from 'path';
 import {
   IdentityWallet,
   byteEncoder,
@@ -11,9 +10,7 @@ import {
   CredentialStatusResolverRegistry,
   RHSResolver,
   CredentialStatusType,
-  FSCircuitStorage,
-  EthStateStorage,
-  NativeProver
+  EthStateStorage
 } from '../../src';
 import {
   MOCK_STATE_STORAGE,

--- a/tests/proofs/mtp-onchain.test.ts
+++ b/tests/proofs/mtp-onchain.test.ts
@@ -116,8 +116,7 @@ describe('mtp onchain proofs', () => {
       new RHSResolver(dataStorage.states)
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
-    const prover = new NativeProver(circuitStorage);
-    idWallet = new IdentityWallet(kms, dataStorage, credWallet, { prover });
+    idWallet = new IdentityWallet(kms, dataStorage, credWallet);
 
     proofService = new ProofService(idWallet, credWallet, circuitStorage, mockStateStorage);
   });

--- a/tests/proofs/mtp-onchain.test.ts
+++ b/tests/proofs/mtp-onchain.test.ts
@@ -191,7 +191,13 @@ describe('mtp onchain proofs', () => {
       (dataStorage.states as EthStateStorage).provider
     );
 
-    const txId = await proofService.transitState(issuerDID, res.oldTreeState, true, ethSigner);
+    const txId = await proofService.transitState(
+      issuerDID,
+      res.oldTreeState,
+      true,
+      dataStorage.states,
+      ethSigner
+    );
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       issuerDID,

--- a/tests/proofs/mtp-onchain.test.ts
+++ b/tests/proofs/mtp-onchain.test.ts
@@ -18,7 +18,7 @@ import {
   CredentialWallet,
   RHSResolver
 } from '../../src/credentials';
-import { NativeProver, ProofService } from '../../src/proof';
+import { ProofService } from '../../src/proof';
 import { CircuitId } from '../../src/circuits';
 import { ethers } from 'ethers';
 import { EthStateStorage } from '../../src/storage/blockchain/state';

--- a/tests/proofs/mtp-onchain.test.ts
+++ b/tests/proofs/mtp-onchain.test.ts
@@ -18,7 +18,7 @@ import {
   CredentialWallet,
   RHSResolver
 } from '../../src/credentials';
-import { ProofService } from '../../src/proof';
+import { NativeProver, ProofService } from '../../src/proof';
 import { CircuitId } from '../../src/circuits';
 import { ethers } from 'ethers';
 import { EthStateStorage } from '../../src/storage/blockchain/state';
@@ -116,7 +116,8 @@ describe('mtp onchain proofs', () => {
       new RHSResolver(dataStorage.states)
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
-    idWallet = new IdentityWallet(kms, dataStorage, credWallet);
+    const prover = new NativeProver(circuitStorage);
+    idWallet = new IdentityWallet(kms, dataStorage, credWallet, { prover });
 
     proofService = new ProofService(idWallet, credWallet, circuitStorage, mockStateStorage);
   });
@@ -190,13 +191,7 @@ describe('mtp onchain proofs', () => {
       (dataStorage.states as EthStateStorage).provider
     );
 
-    const txId = await proofService.transitState(
-      issuerDID,
-      res.oldTreeState,
-      true,
-      dataStorage.states,
-      ethSigner
-    );
+    const txId = await proofService.transitState(issuerDID, res.oldTreeState, true, ethSigner);
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       issuerDID,

--- a/tests/proofs/mtp-onchain.test.ts
+++ b/tests/proofs/mtp-onchain.test.ts
@@ -58,6 +58,9 @@ describe('mtp onchain proofs', () => {
     publishState: async () => {
       return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
     },
+    publishStateGeneric: async () => {
+      return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+    },
     getGISTProof: (): Promise<StateProof> => {
       return Promise.resolve({
         root: 0n,

--- a/tests/proofs/mtp.test.ts
+++ b/tests/proofs/mtp.test.ts
@@ -13,7 +13,7 @@ import { InMemoryPrivateKeyStore } from '../../src/kms/store';
 import { IDataStorage, IStateStorage } from '../../src/storage/interfaces';
 import { InMemoryDataSource, InMemoryMerkleTreeStorage } from '../../src/storage/memory';
 import { CredentialRequest, CredentialWallet } from '../../src/credentials';
-import { ProofService } from '../../src/proof';
+import { NativeProver, ProofService } from '../../src/proof';
 import { CircuitId } from '../../src/circuits';
 import { ethers } from 'ethers';
 import { EthStateStorage } from '../../src/storage/blockchain/state';
@@ -116,7 +116,9 @@ describe('mtp proofs', () => {
       new RHSResolver(dataStorage.states)
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
-    idWallet = new IdentityWallet(kms, dataStorage, credWallet);
+
+    const prover = new NativeProver(circuitStorage);
+    idWallet = new IdentityWallet(kms, dataStorage, credWallet, { prover });
 
     proofService = new ProofService(idWallet, credWallet, circuitStorage, mockStateStorage);
   });
@@ -166,13 +168,7 @@ describe('mtp proofs', () => {
       walletKey,
       (dataStorage.states as EthStateStorage).provider
     );
-    const txId = await proofService.transitState(
-      issuerDID,
-      res.oldTreeState,
-      true,
-      dataStorage.states,
-      ethSigner
-    );
+    const txId = await proofService.transitState(issuerDID, res.oldTreeState, true, ethSigner);
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       issuerDID,
@@ -257,13 +253,7 @@ describe('mtp proofs', () => {
       (dataStorage.states as EthStateStorage).provider
     );
 
-    const txId = await proofService.transitState(
-      issuerDID,
-      res.oldTreeState,
-      true,
-      dataStorage.states,
-      ethSigner
-    );
+    const txId = await proofService.transitState(issuerDID, res.oldTreeState, true, ethSigner);
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       issuerDID,

--- a/tests/proofs/mtp.test.ts
+++ b/tests/proofs/mtp.test.ts
@@ -168,7 +168,13 @@ describe('mtp proofs', () => {
       walletKey,
       (dataStorage.states as EthStateStorage).provider
     );
-    const txId = await proofService.transitState(issuerDID, res.oldTreeState, true, ethSigner);
+    const txId = await proofService.transitState(
+      issuerDID,
+      res.oldTreeState,
+      true,
+      dataStorage.states,
+      ethSigner
+    );
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       issuerDID,
@@ -253,7 +259,13 @@ describe('mtp proofs', () => {
       (dataStorage.states as EthStateStorage).provider
     );
 
-    const txId = await proofService.transitState(issuerDID, res.oldTreeState, true, ethSigner);
+    const txId = await proofService.transitState(
+      issuerDID,
+      res.oldTreeState,
+      true,
+      dataStorage.states,
+      ethSigner
+    );
 
     const credsWithIden3MTPProof = await idWallet.generateIden3SparseMerkleTreeProof(
       issuerDID,

--- a/tests/proofs/mtp.test.ts
+++ b/tests/proofs/mtp.test.ts
@@ -117,8 +117,7 @@ describe('mtp proofs', () => {
     );
     credWallet = new CredentialWallet(dataStorage, resolvers);
 
-    const prover = new NativeProver(circuitStorage);
-    idWallet = new IdentityWallet(kms, dataStorage, credWallet, { prover });
+    idWallet = new IdentityWallet(kms, dataStorage, credWallet);
 
     proofService = new ProofService(idWallet, credWallet, circuitStorage, mockStateStorage);
   });

--- a/tests/proofs/mtp.test.ts
+++ b/tests/proofs/mtp.test.ts
@@ -13,7 +13,7 @@ import { InMemoryPrivateKeyStore } from '../../src/kms/store';
 import { IDataStorage, IStateStorage } from '../../src/storage/interfaces';
 import { InMemoryDataSource, InMemoryMerkleTreeStorage } from '../../src/storage/memory';
 import { CredentialRequest, CredentialWallet } from '../../src/credentials';
-import { NativeProver, ProofService } from '../../src/proof';
+import { ProofService } from '../../src/proof';
 import { CircuitId } from '../../src/circuits';
 import { ethers } from 'ethers';
 import { EthStateStorage } from '../../src/storage/blockchain/state';

--- a/tests/proofs/mtp.test.ts
+++ b/tests/proofs/mtp.test.ts
@@ -54,6 +54,9 @@ describe('mtp proofs', () => {
     publishState: async () => {
       return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
     },
+    publishStateGeneric: async () => {
+      return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+    },
     getGISTProof: (): Promise<StateProof> => {
       return Promise.resolve({
         root: 0n,

--- a/tests/proofs/sig-onchain.test.ts
+++ b/tests/proofs/sig-onchain.test.ts
@@ -45,6 +45,9 @@ describe('sig onchain proofs', () => {
     publishState: async () => {
       return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
     },
+    publishStateGeneric: async () => {
+      return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+    },
     getGISTProof: (): Promise<StateProof> => {
       return Promise.resolve({
         root: 0n,

--- a/tests/proofs/sig.test.ts
+++ b/tests/proofs/sig.test.ts
@@ -44,6 +44,9 @@ describe('sig proofs', () => {
     publishState: async () => {
       return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
     },
+    publishStateGeneric: async () => {
+      return '0xc837f95c984892dbcc3ac41812ecb145fedc26d7003202c50e1b87e226a9b33c';
+    },
     getStateInfoByIdAndState: async () => {
       throw new Error(VerifiableConstants.ERRORS.IDENTITY_DOES_NOT_EXIST);
     },

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { JSONObject, mergeObjects } from '../../src';
+import { buildDIDFromEthPubKey, JSONObject, mergeObjects } from '../../src';
+import { Blockchain, buildDIDType, DidMethod, NetworkId } from '@iden3/js-iden3-core';
 
 describe('merge credential subjects to create query', () => {
   it('should merge two valid JSONObjects correctly', () => {
@@ -147,5 +148,18 @@ describe('merge credential subjects to create query', () => {
         mergeObjects(testCase.subj1 as JSONObject, testCase.subj2 as JSONObject)
       ).to.deep.equal(testCase.expectedResult);
     }
+  });
+});
+
+describe('build did from ethereum public key', () => {
+  it('should build did from ethereum public key correctly', async () => {
+    const pubKeyHexEth =
+      '8318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed753547f11ca8696646f2f3acb08e31016afac23e630c5d11f59f61fef57b0d2aa5';
+    const didType = buildDIDType(DidMethod.Iden3, Blockchain.Polygon, NetworkId.Amoy);
+    const did = buildDIDFromEthPubKey(didType, pubKeyHexEth);
+
+    expect(did.string()).to.equal(
+      'did:iden3:polygon:amoy:x6x5sor7zpycB7z7Q9348dXJxZ9s5b9AgmPeSccZz'
+    );
   });
 });


### PR DESCRIPTION
- Manage ethereum based identities. 
 1. Implement create method.
 a. add bjj key Auth credential.
 b. first state transtition must be mandatory after adding the Auth credential.
 2. Implement state transition for ethereum identities. (transitState / transitStateGeneric)
 3. Test flow when ethereum based identity is an issuer.


- Fix for sec256k1 when private key generation is less than 32 bytes in hex representation

Review
1. We need to sign a new auth bjj key with old one (e.g. k2 with k1). If there is no k1 and state is genesis - we can add MTP as now.  
2. For ethereum identity and for k2 we can add Iden3SparseMerkeTreeProof after the state transition. 
3. Write some tests for key rotation / adding new keys.
