### PR TITLE
Make body required for all messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@0xpolygonid/js-sdk",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@0xpolygonid/js-sdk",
-      "version": "1.17.3",
+      "version": "1.17.4",
       "license": "MIT or Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xpolygonid/js-sdk",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "description": "SDK to work with Polygon ID",
   "main": "dist/node/cjs/index.js",
   "module": "dist/node/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lint": "eslint --fix --ext .ts src/** tests/**",
     "lint:check": "eslint --ext .ts src/** tests/**",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "format:check": "prettier \"src/**/*.ts\" \"tests/**/*.ts\" --check"
+    "format:check": "prettier \"src/**/*.ts\" \"tests/**/*.ts\" --check",
+    "watch": "tsc --watch"
   },
   "repository": {
     "type": "git",

--- a/src/iden3comm/types/protocol/credentials.ts
+++ b/src/iden3comm/types/protocol/credentials.ts
@@ -67,7 +67,7 @@ export type IssuanceMessageBody = {
 
 /** CredentialFetchRequestMessage represent Iden3message for credential fetch request */
 export type CredentialFetchRequestMessage = BasicMessage & {
-  body?: CredentialFetchRequestMessageBody;
+  body: CredentialFetchRequestMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.CREDENTIAL_FETCH_REQUEST_MESSAGE_TYPE;
 };
 
@@ -85,7 +85,7 @@ export type Schema = {
 
 /** CredentialRefreshMessage represent Iden3message for credential refresh request */
 export type CredentialRefreshMessage = Required<BasicMessage> & {
-  body?: CredentialRefreshMessageBody;
+  body: CredentialRefreshMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.CREDENTIAL_REFRESH_MESSAGE_TYPE;
 };
 

--- a/src/iden3comm/types/protocol/messages.ts
+++ b/src/iden3comm/types/protocol/messages.ts
@@ -3,7 +3,7 @@ import { PROTOCOL_MESSAGE_TYPE } from '../../constants';
 
 /**  MessageFetchRequestMessage represent Iden3message for message fetch request. */
 export type MessageFetchRequestMessage = Required<BasicMessage> & {
-  body?: MessageFetchRequestMessageBody;
+  body: MessageFetchRequestMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.CREDENTIAL_FETCH_REQUEST_MESSAGE_TYPE;
 };
 

--- a/src/iden3comm/types/protocol/proof.ts
+++ b/src/iden3comm/types/protocol/proof.ts
@@ -4,7 +4,7 @@ import { ZeroKnowledgeProofRequest, ZeroKnowledgeProofResponse } from './auth';
 
 /** ProofGenerationRequestMessage is struct the represents body for proof generation request */
 export type ProofGenerationRequestMessage = Required<BasicMessage> & {
-  body?: ProofGenerationRequestMessageBody;
+  body: ProofGenerationRequestMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.PROOF_GENERATION_REQUEST_MESSAGE_TYPE;
 };
 
@@ -15,7 +15,7 @@ export type ProofGenerationRequestMessageBody = {
 
 /** ProofGenerationResponseMessage is struct the represents body for proof generation request */
 export type ProofGenerationResponseMessage = Required<BasicMessage> & {
-  body?: ResponseMessageBody;
+  body: ResponseMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.PROOF_GENERATION_RESPONSE_MESSAGE_TYPE;
 };
 

--- a/src/iden3comm/types/protocol/proposal-request.ts
+++ b/src/iden3comm/types/protocol/proposal-request.ts
@@ -3,7 +3,7 @@ import { PROTOCOL_MESSAGE_TYPE } from '../../constants';
 
 /** @beta ProposalRequestMessage is struct the represents proposal-request message */
 export type ProposalRequestMessage = BasicMessage & {
-  body?: ProposalRequestMessageBody;
+  body: ProposalRequestMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.PROPOSAL_REQUEST_MESSAGE_TYPE;
 };
 
@@ -16,7 +16,7 @@ export type ProposalRequestMessageBody = {
 
 /** @beta  ProposalMessage is struct the represents proposal message */
 export type ProposalMessage = BasicMessage & {
-  body?: ProposalMessageBody;
+  body: ProposalMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.PROPOSAL_MESSAGE_TYPE;
 };
 
@@ -33,7 +33,7 @@ export type ProposalRequestCredential = {
 
 /** @beta Proposal is struct the represents proposal inside proposal protocol message */
 export type Proposal = {
-  credentials?: ProposalRequestCredential[];
+  credentials: ProposalRequestCredential[];
   type: string;
   url?: string;
   expiration?: string;

--- a/src/iden3comm/types/protocol/revocation.ts
+++ b/src/iden3comm/types/protocol/revocation.ts
@@ -4,7 +4,7 @@ import { PROTOCOL_MESSAGE_TYPE } from '../../constants';
 
 /** RevocationStatusRequestMessage is struct the represents body for proof generation request */
 export type RevocationStatusRequestMessage = BasicMessage & {
-  body?: RevocationStatusRequestMessageBody;
+  body: RevocationStatusRequestMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.REVOCATION_STATUS_REQUEST_MESSAGE_TYPE;
 };
 
@@ -15,7 +15,7 @@ export type RevocationStatusRequestMessageBody = {
 
 /** RevocationStatusResponseMessage is struct the represents body for proof generation request */
 export type RevocationStatusResponseMessage = Required<BasicMessage> & {
-  body?: RevocationStatusResponseMessageBody;
+  body: RevocationStatusResponseMessageBody;
   type: typeof PROTOCOL_MESSAGE_TYPE.REVOCATION_STATUS_RESPONSE_MESSAGE_TYPE;
 };
 

--- a/tests/handlers/credential-proposal.test.ts
+++ b/tests/handlers/credential-proposal.test.ts
@@ -225,7 +225,8 @@ describe('proposal-request handler', () => {
       {
         type: 'WebVerificationForm',
         url: 'http://issuer-agent.com/verify?anyUniqueIdentifierOfSession=55',
-        description: 'you can pass the verification on our KYC provider by following the next link'
+        description: 'you can pass the verification on our KYC provider by following the next link',
+        credentials: []
       }
     ]);
 


### PR DESCRIPTION
This PR makes the property `body` required for all the messages except the `BasicMessage`.