### PR TITLE
fix issue with "Metadata not supported yet"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@0xpolygonid/js-sdk",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@0xpolygonid/js-sdk",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "license": "MIT or Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xpolygonid/js-sdk",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "SDK to work with Polygon ID",
   "main": "dist/node/cjs/index.js",
   "module": "dist/node/esm/index.js",

--- a/src/storage/blockchain/onchain-zkp-verifier.ts
+++ b/src/storage/blockchain/onchain-zkp-verifier.ts
@@ -334,7 +334,7 @@ export class OnChainZKPVerifier implements IOnChainZKPVerifier {
         }
       }
 
-      const metadata = this.packMetadatas(metadataArr);
+      const metadata = metadataArr.length ? this.packMetadatas(metadataArr) : '0x';
       payload.push({
         requestId: requestID,
         zkProof: zkProofEncoded,


### PR DESCRIPTION
we have added in contracts this check for metadata:
` if (response.data.length > 0) {
                revert("Metadata not supported yet");
    }`
    
   if we encode an empty array in sdk:
   metas = [];
   `this._abiCoder.encode(['tuple(' + 'string key,' + 'bytes value' + ')[]'], [metas]);`
   it would give not empty meta:
   `0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000`