### PR TITLE
Fix/issuance 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@0xpolygonid/js-sdk",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@0xpolygonid/js-sdk",
-      "version": "1.43.0",
+      "version": "1.44.0",
       "license": "MIT or Apache-2.0",
       "dependencies": {
         "@iden3/onchain-non-merklized-issuer-base-abi": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xpolygonid/js-sdk",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "SDK to work with Polygon ID",
   "source": "./src/index.ts",
   "exports": {

--- a/src/iden3comm/handlers/fetch.ts
+++ b/src/iden3comm/handlers/fetch.ts
@@ -461,15 +461,15 @@ export class FetchHandler
       throw new Error('credential is missing in issuance response message');
     }
 
-    if (
-      !(issuanceMsg.body.credential instanceof W3CCredential) &&
-      typeof issuanceMsg.body.credential === 'object'
-    ) {
-      issuanceMsg.body.credential = W3CCredential.fromJSON(issuanceMsg.body.credential);
-    } else if (!(issuanceMsg.body.credential instanceof W3CCredential)) {
-      throw new Error('credential object is not properly unmarshaled');
+    let credential = issuanceMsg.body.credential;
+
+    if (!(credential instanceof W3CCredential)) {
+      if (typeof credential !== 'object' || credential === null) {
+        throw new Error('credential object is not properly unmarshaled');
+      }
+      credential = W3CCredential.fromJSON(credential);
     }
-    await this.opts.credentialWallet.save(issuanceMsg.body.credential);
+    await this.opts.credentialWallet.save(credential);
 
     return null;
   }

--- a/src/iden3comm/handlers/fetch.ts
+++ b/src/iden3comm/handlers/fetch.ts
@@ -461,7 +461,9 @@ export class FetchHandler
       throw new Error('credential is missing in issuance response message');
     }
 
-    if (!(issuanceMsg.body.credential instanceof W3CCredential)) {
+    if (!(issuanceMsg.body.credential instanceof W3CCredential) && typeof issuanceMsg.body.credential === 'object') {
+       issuanceMsg.body.credential = W3CCredential.fromJSON(issuanceMsg.body.credential);
+    } else if (!(issuanceMsg.body.credential instanceof W3CCredential)) {
       throw new Error('credential object is not properly unmarshaled');
     }
     await this.opts.credentialWallet.save(issuanceMsg.body.credential);
@@ -484,9 +486,6 @@ export class FetchHandler
     if (!opts?.allowExpiredMessages) {
       verifyExpiresTime(issuanceMsg);
     }
-    // unpack returns body.credential as JSON object, we need to assign type to it.
-    // TODO: add unmarshaler for messages
-    issuanceMsg.body.credential = W3CCredential.fromJSON(issuanceMsg.body.credential);
     await this.handleIssuanceResponseMsg(issuanceMsg);
     return Uint8Array.from([]);
   }

--- a/src/iden3comm/handlers/fetch.ts
+++ b/src/iden3comm/handlers/fetch.ts
@@ -461,8 +461,11 @@ export class FetchHandler
       throw new Error('credential is missing in issuance response message');
     }
 
-    if (!(issuanceMsg.body.credential instanceof W3CCredential) && typeof issuanceMsg.body.credential === 'object') {
-       issuanceMsg.body.credential = W3CCredential.fromJSON(issuanceMsg.body.credential);
+    if (
+      !(issuanceMsg.body.credential instanceof W3CCredential) &&
+      typeof issuanceMsg.body.credential === 'object'
+    ) {
+      issuanceMsg.body.credential = W3CCredential.fromJSON(issuanceMsg.body.credential);
     } else if (!(issuanceMsg.body.credential instanceof W3CCredential)) {
       throw new Error('credential object is not properly unmarshaled');
     }


### PR DESCRIPTION
This pull request updates the SDK version and improves the handling of credential objects during issuance responses. The most significant change is a fix to ensure that credentials are properly unmarshaled before being saved, enhancing the robustness of credential processing.

Version update:

* Bumped the package version from `1.43.0` to `1.44.0` in `package.json` to reflect the new changes.

Credential handling improvements:

* Updated `FetchHandler` in `src/iden3comm/handlers/fetch.ts` to check if the credential in the issuance response is a plain object and, if so, convert it using `W3CCredential.fromJSON` before saving. This ensures that credentials are always properly unmarshaled and prevents errors when saving credentials.
* Removed redundant code that previously always attempted to unmarshal the credential, since the new logic handles unmarshaling conditionally.