### PR TITLE
feat: add explicit credentials option for proof requests

### DIFF
--- a/src/iden3comm/handlers/auth.ts
+++ b/src/iden3comm/handlers/auth.ts
@@ -13,13 +13,14 @@ import {
   Attachment
 } from '../types';
 import { DID, getUnixTimestamp } from '@iden3/js-iden3-core';
-import { ProvingMethodAlg, proving } from '@iden3/js-jwz';
+import { ProvingMethodAlg } from '@iden3/js-jwz';
 
 import * as uuid from 'uuid';
 import { ProofQuery } from '../../verifiable';
 import { byteDecoder, byteEncoder } from '../../utils';
 import {
   HandlerPackerParams,
+  ProofRequestCredential,
   initDefaultPackerOptions,
   processZeroKnowledgeProofRequests,
   verifyExpiresTime
@@ -28,14 +29,9 @@ import { CircuitId, getGroupedCircuitIdsWithSubVersions } from '../../circuits';
 import {
   AbstractMessageHandler,
   BasicHandlerOptions,
-  IProtocolMessageHandler,
-  defaultProvingMethodAlg
+  IProtocolMessageHandler
 } from './message-handler';
-import {
-  acceptHasProvingMethodAlg,
-  buildAcceptFromProvingMethodAlg,
-  parseAcceptProfile
-} from '../utils';
+import { getDefaultZKProvingMethodAlg, parseAcceptProfile } from '../utils';
 
 /**
  * Options to pass to createAuthorizationRequest function
@@ -175,6 +171,7 @@ type AuthReqOptions = {
   mediaType?: MediaType;
   bypassProofsCache?: boolean;
   allowExpiredCredentials?: boolean;
+  credentials?: Map<string, ProofRequestCredential>;
 };
 
 type AuthRespOptions = {
@@ -284,7 +281,8 @@ export class AuthHandler
         mediaType,
         supportedCircuits: this._supportedCircuits,
         bypassProofsCache: ctx.bypassProofsCache,
-        allowExpiredCredentials: ctx.allowExpiredCredentials
+        allowExpiredCredentials: ctx.allowExpiredCredentials,
+        credentials: ctx.credentials
       }
     );
 
@@ -335,7 +333,8 @@ export class AuthHandler
     const msgBytes = byteEncoder.encode(JSON.stringify(authResponse));
 
     const packerOpts = initDefaultPackerOptions(opts.mediaType, opts.packerOptions, {
-      provingMethodAlg: this.getDefaultProvingMethodAlg(
+      provingMethodAlg: getDefaultZKProvingMethodAlg(
+        this._packerMgr,
         opts.preferredAuthProvingMethod,
         authRequest.body.accept
       ),
@@ -538,41 +537,5 @@ export class AuthHandler
       mediaType = ctx.mediaType;
     }
     return mediaType;
-  }
-
-  private getDefaultProvingMethodAlg(
-    preferredAuthProvingMethod?: ProvingMethodAlg,
-    accept?: string[]
-  ): ProvingMethodAlg {
-    // if no accept is given, return default
-    if (!accept?.length) {
-      return defaultProvingMethodAlg;
-    }
-
-    const preferredOrder = [
-      proving.provingMethodGroth16AuthV3_8_32Instance.methodAlg,
-      proving.provingMethodGroth16AuthV3Instance.methodAlg
-    ];
-    if (preferredAuthProvingMethod) {
-      const idx = preferredOrder.indexOf(preferredAuthProvingMethod);
-      if (idx !== -1) {
-        preferredOrder.splice(idx, 1);
-      }
-      preferredOrder.unshift(preferredAuthProvingMethod);
-    }
-
-    for (const methodAlg of preferredOrder) {
-      if (
-        this._packerMgr.isProfileSupported(
-          MediaType.ZKPMessage,
-          buildAcceptFromProvingMethodAlg(methodAlg)
-        ) &&
-        acceptHasProvingMethodAlg(accept, methodAlg)
-      ) {
-        return methodAlg;
-      }
-    }
-
-    return defaultProvingMethodAlg;
   }
 }

--- a/src/iden3comm/handlers/common.ts
+++ b/src/iden3comm/handlers/common.ts
@@ -48,7 +48,7 @@ export type HandlerPackerParams =
  * @param requestScope - An array of ZeroKnowledgeProofRequest objects.
  * @returns A Map<number, { query: ZeroKnowledgeProofQuery; linkNonce: number }> representing the grouped queries.
  */
-const getGroupedQueries = (
+export const getGroupedQueries = (
   requestScope: ZeroKnowledgeProofRequest[]
 ): Map<number, { query: ZeroKnowledgeProofQuery; linkNonce: number }> =>
   requestScope.reduce((acc, proofReq) => {
@@ -89,6 +89,15 @@ const getGroupedQueries = (
   }, new Map<number, { query: ZeroKnowledgeProofQuery; linkNonce: number }>());
 
 /**
+ * A credential explicitly provided for a proof request, bypassing credential lookup.
+ * @public
+ */
+export type ProofRequestCredential = {
+  credential: W3CCredential;
+  linkNonce?: bigint;
+};
+
+/**
  * Processes zero knowledge proof requests.
  *
  * @param to - The identifier of the recipient.
@@ -111,6 +120,7 @@ export const processZeroKnowledgeProofRequests = async (
     challenge?: bigint;
     bypassProofsCache?: boolean;
     allowExpiredCredentials?: boolean;
+    credentials?: Map<string, ProofRequestCredential>;
   }
 ): Promise<ZeroKnowledgeProofResponse[]> => {
   const requestScope = requests ?? [];
@@ -140,6 +150,22 @@ export const processZeroKnowledgeProofRequests = async (
       }
 
       const query = proofReq.query;
+
+      const providedCredential = opts.credentials?.get(proofReq.id.toString());
+      if (providedCredential) {
+        zkpRes = await proofService.generateProof(proofReq, to, {
+          verifierDid: from,
+          challenge: opts.challenge,
+          skipRevocation: Boolean(query?.skipClaimRevocationCheck),
+          credential: providedCredential.credential,
+          linkNonce: providedCredential.linkNonce,
+          bypassCache: opts.bypassProofsCache,
+          allowExpiredCredentials: opts.allowExpiredCredentials
+        });
+        zkpResponses.push(zkpRes);
+        continue;
+      }
+
       const groupId = query?.groupId as number | undefined;
       const combinedQueryData = combinedQueries.get(groupId as number);
 

--- a/src/iden3comm/handlers/message-handler.ts
+++ b/src/iden3comm/handlers/message-handler.ts
@@ -4,15 +4,13 @@ import { RevocationStatusMessageHandlerOptions } from './revocation-status';
 import { ContractMessageHandlerOptions } from './contract-request';
 import { PaymentHandlerOptions, PaymentRequestMessageHandlerOptions } from './payment';
 import { MediaType } from '../constants';
-import { ProvingMethodAlg, Token, proving } from '@iden3/js-jwz';
+import { ProvingMethodAlg, Token } from '@iden3/js-jwz';
 import { DID } from '@iden3/js-iden3-core';
 import { verifyExpiresTime } from './common';
 import { byteDecoder } from '../../utils';
+import { defaultProvingMethodAlg } from '../utils/accept-profile';
 
-/**
- * Default proving method algorithm for ZKP messages
- */
-export const defaultProvingMethodAlg = proving.provingMethodGroth16AuthV2Instance.methodAlg;
+export { defaultProvingMethodAlg };
 
 /**
  * iden3 Basic protocol message handler options

--- a/src/iden3comm/utils/accept-profile.ts
+++ b/src/iden3comm/utils/accept-profile.ts
@@ -1,4 +1,4 @@
-import { ProvingMethodAlg } from '@iden3/js-jwz';
+import { proving, ProvingMethodAlg } from '@iden3/js-jwz';
 import {
   MediaType,
   ProtocolVersion,
@@ -7,7 +7,8 @@ import {
   AcceptJwsAlgorithms,
   AcceptJweKEKAlgorithms
 } from '../constants';
-import { AcceptProfile } from '../types';
+import { AcceptProfile, IPackageManager } from '../types';
+import { defaultProvingMethodAlg } from '../handlers/message-handler';
 
 function isProtocolVersion(value: string): boolean {
   return Object.values(ProtocolVersion).includes(value as ProtocolVersion);
@@ -164,4 +165,41 @@ export const parseAcceptProfile = (profile: string): AcceptProfile => {
     circuits,
     alg
   };
+};
+
+export const getDefaultZKProvingMethodAlg = (
+  packerMgr: IPackageManager,
+  preferredAuthProvingMethod?: ProvingMethodAlg,
+  accept?: string[]
+): ProvingMethodAlg => {
+  // if no accept is given, return default
+  if (!accept?.length) {
+    return defaultProvingMethodAlg;
+  }
+
+  const preferredOrder = [
+    proving.provingMethodGroth16AuthV3_8_32Instance.methodAlg,
+    proving.provingMethodGroth16AuthV3Instance.methodAlg
+  ];
+  if (preferredAuthProvingMethod) {
+    const idx = preferredOrder.indexOf(preferredAuthProvingMethod);
+    if (idx !== -1) {
+      preferredOrder.splice(idx, 1);
+    }
+    preferredOrder.unshift(preferredAuthProvingMethod);
+  }
+
+  for (const methodAlg of preferredOrder) {
+    if (
+      packerMgr.isProfileSupported(
+        MediaType.ZKPMessage,
+        buildAcceptFromProvingMethodAlg(methodAlg)
+      ) &&
+      acceptHasProvingMethodAlg(accept, methodAlg)
+    ) {
+      return methodAlg;
+    }
+  }
+
+  return defaultProvingMethodAlg;
 };

--- a/src/iden3comm/utils/accept-profile.ts
+++ b/src/iden3comm/utils/accept-profile.ts
@@ -8,7 +8,11 @@ import {
   AcceptJweKEKAlgorithms
 } from '../constants';
 import { AcceptProfile, IPackageManager } from '../types';
-import { defaultProvingMethodAlg } from '../handlers/message-handler';
+
+/**
+ * Default proving method algorithm for ZKP messages
+ */
+export const defaultProvingMethodAlg = proving.provingMethodGroth16AuthV2Instance.methodAlg;
 
 function isProtocolVersion(value: string): boolean {
   return Object.values(ProtocolVersion).includes(value as ProtocolVersion);


### PR DESCRIPTION
## Summary

Adds a `credentials` option to `processZeroKnowledgeProofRequests` (and wires it through the auth handler) that lets callers explicitly supply a credential — with an optional `linkNonce` — per proof request via a `Map<string, ProofRequestCredential>` keyed by request id. When a credential is provided for a request, it is used directly via `generateProof` and the normal credential lookup / group handling is bypassed.

Also extracts the private `AuthHandler.getDefaultProvingMethodAlg` into a reusable exported util `getDefaultZKProvingMethodAlg` in `accept-profile.ts`, and exports `getGroupedQueries`.